### PR TITLE
SPRacingH7RF - Fix incorrect button pin defination.

### DIFF
--- a/configs/SPRACINGH7RF/config.h
+++ b/configs/SPRACINGH7RF/config.h
@@ -34,9 +34,9 @@
 #define USE_SPRACING_PERSISTENT_RTC_WORKAROUND
 
 #define USE_BUTTONS
-#define BUTTON_A_PIN            PE4
+#define BUTTON_A_PIN            PC14
 #define BUTTON_A_PIN_INVERTED
-#define BUTTON_B_PIN            PE4
+#define BUTTON_B_PIN            PC14
 #define BUTTON_B_PIN_INVERTED
 
 #define USE_OCTOSPI


### PR DESCRIPTION
* It was conflicting with the beeper, causing a lock-up on boot.