### PR TITLE
FIX CHONKERH735 target MCU

### DIFF
--- a/configs/CHONKERH735/config.h
+++ b/configs/CHONKERH735/config.h
@@ -25,7 +25,7 @@ Details: https://github.com/crteensy/yolo-chonker/tree/as-built-20230303
 
 #pragma once
 
-#define FC_TARGET_MCU           STM32H723
+#define FC_TARGET_MCU           STM32H725
 
 #define BOARD_NAME              CHONKERH735
 #define MANUFACTURER_ID         YOLO


### PR DESCRIPTION
The taget contained H723, which was wrong. Fixed it.

Support for the H725 MCU is on the way.