### PR TITLE
Add NEUTRONRCF745VTX config file

### DIFF
--- a/configs/NEUTRONRCF745VTX/config.h
+++ b/configs/NEUTRONRCF745VTX/config.h
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32F745
+
+#define BOARD_NAME        NEUTRONRCF745VTX
+#define MANUFACTURER_ID   NERC
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_ACCGYRO_BMI270
+#define USE_FLASH
+#define USE_FLASH_M25P16
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_MAG
+#define USE_MAG_QMC5883
+#define USE_MAX7456
+
+#define BEEPER_PIN           PD2
+
+#define MOTOR1_PIN           PB0
+#define MOTOR2_PIN           PB1
+#define MOTOR3_PIN           PB4
+#define MOTOR4_PIN           PB5
+
+#define MOTOR5_PIN           PD12
+#define MOTOR6_PIN           PD13
+#define MOTOR7_PIN           PC8
+#define MOTOR8_PIN           PC9
+
+#define LED_STRIP_PIN        PA8
+#define UART1_TX_PIN         PA9
+#define UART2_TX_PIN         PA2
+#define UART3_TX_PIN         PB10
+#define UART4_TX_PIN         PA0
+#define UART6_TX_PIN         PC6
+#define UART7_TX_PIN         PE8
+#define UART8_TX_PIN         PE1
+#define UART1_RX_PIN         PA10
+#define UART2_RX_PIN         PA3
+#define UART3_RX_PIN         PB11
+#define UART4_RX_PIN         PA1
+#define UART6_RX_PIN         PC7
+#define UART7_RX_PIN         PE7
+#define UART8_RX_PIN         PE0
+#define I2C1_SCL_PIN         PB8
+#define I2C2_SCL_PIN         PB10
+#define I2C1_SDA_PIN         PB9
+#define I2C2_SDA_PIN         PB11
+#define LED0_PIN             PC13
+#define PINIO1_PIN           PE13
+#define PINIO2_PIN           PC14
+
+#define SPI1_SCK_PIN         PA5
+#define SPI2_SCK_PIN         PB13
+#define SPI3_SCK_PIN         PC10
+#define SPI4_SCK_PIN         PE2
+
+#define SPI1_SDI_PIN         PA6
+#define SPI2_SDI_PIN         PB14
+#define SPI3_SDI_PIN         PC11
+#define SPI4_SDI_PIN         PE5
+
+#define SPI1_SDO_PIN         PA7
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SDO_PIN         PC12
+#define SPI4_SDO_PIN         PE6
+
+#define CAMERA_CONTROL_PIN   PB3
+#define ADC_VBAT_PIN         PC3
+#define ADC_RSSI_PIN         PC5
+#define ADC_CURR_PIN         PC2
+#define ADC_EXTERNAL1_PIN    PC1
+#define FLASH_CS_PIN         PA15
+#define MAX7456_SPI_CS_PIN   PE4
+#define GYRO_1_EXTI_PIN      PD0
+#define GYRO_2_EXTI_PIN      PD8
+#define GYRO_1_CS_PIN        PA4
+#define GYRO_2_CS_PIN        PB12
+
+// TIM1, CH1, PA8, 1
+// TIM2, CH2, PB3, 2
+// TIM8, CH2N, PB0, 1, 3, 8
+// TIM8, CH3N, PB1, 1, 3, 8
+// TIM3, CH1, PB4, 3
+// TIM3, CH2, PB5, 3
+// TIM4, CH1, PD12, 4
+// TIM4, CH2, PD13, 4
+// TIM3, CH3, PC8, 3, 8
+// TIM3, CH4, PC9, 3, 8
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PA8 , 1,  0) \
+    TIMER_PIN_MAP( 1, PB3 , 1,  0) \
+    TIMER_PIN_MAP( 2, PB0 , 3,  0) \
+    TIMER_PIN_MAP( 3, PB1 , 3,  0) \
+    TIMER_PIN_MAP( 4, PB4 , 1,  0) \
+    TIMER_PIN_MAP( 5, PB5 , 1,  0) \
+    TIMER_PIN_MAP( 6, PD12, 1,  0) \
+    TIMER_PIN_MAP( 7, PD13, 1,  0) \
+    TIMER_PIN_MAP( 8, PC8 , 1,  1) \
+    TIMER_PIN_MAP( 9, PC9 , 1,  2)
+
+
+#define ADC1_DMA_OPT        0
+
+#define MAG_ALIGN CW180_DEG
+#define MAG_ALIGN_YAW 1800
+
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define BARO_I2C_INSTANCE (I2CDEV_1)
+
+#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
+//TODO #define DSHOT_BIDIR ON
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SCALE 210
+#define DEFAULT_CURRENT_METER_SCALE 100
+#define BEEPER_INVERTED
+#define PINIO1_CONFIG 129
+#define PINIO1_BOX 0
+#define PINIO2_BOX 40
+#define PINIO3_BOX 41
+#define PINIO4_BOX 42
+#define MAX7456_SPI_INSTANCE SPI4
+#define FLASH_SPI_INSTANCE SPI3
+#define USE_SPI_GYRO
+#define GYRO_1_SPI_INSTANCE SPI1
+#define GYRO_2_SPI_INSTANCE SPI2
+#define GYRO_1_ALIGN CW270_DEG
+#define GYRO_1_ALIGN_YAW 2700
+


### PR DESCRIPTION

![27f0d35d4964936e6acbca966bc20ae](https://github.com/betaflight/config/assets/10217966/53048419-69a7-418b-ba5d-7b766d178040)
![18734a111deca3b00c7172748562401](https://github.com/betaflight/config/assets/10217966/3626e140-1127-4b56-8945-d92908cdd21d)
![83f6fccbba86c26089d580c2f645772](https://github.com/betaflight/config/assets/10217966/339e2b47-092b-46cf-a5ac-c86654b7978a)

This commit adds the NEUTRONRCF745VTX configuration file, which includes various settings and pin mappings for the target MCU STM32F745. The configuration enables the use of accelerometer (ACC), gyroscope (GYRO), barometer (BARO), magnetometer (MAG), and MAX7456 OSD. It also defines pin assignments for motors, UARTs, LEDs, SPI interfaces, ADC pins, and timers. Additionally, it sets default values for blackbox device, current meter source and scale, voltage meter source and scale, beeper inversion, PINIO configurations, and gyro alignment.