### PR TITLE
Add FrSky OSD to MatekF722HD target

### DIFF
--- a/configs/MATEKF722HD/config.h
+++ b/configs/MATEKF722HD/config.h
@@ -34,6 +34,7 @@
 #define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
+#define USE_FRSKYOSD
 
 #define BEEPER_PIN              PC13
 #define MOTOR1_PIN              PC8


### PR DESCRIPTION
This FC does not have a MAX7456 OSD, but it has a FrSky OSD on UART6.
http://www.mateksys.com/?portfolio=f722-hd

Should USE_OSD_SD be undefined in this case? Should UART6 be set to FrSky OSD by default?

Should resolve: https://discord.com/channels/868013470023548938/1147742358969004083