### PR TITLE
Add DPS310 to NBD_GALAXYAIO255

### DIFF
--- a/configs/NBD_GALAXYAIO255/config.h
+++ b/configs/NBD_GALAXYAIO255/config.h
@@ -29,6 +29,7 @@
 #define USE_ACCGYRO_BMI270
 #define USE_MAX7456
 #define USE_SDCARD
+#define USE_BARO_DPS310
 
 #define BEEPER_PIN           PA15
 #define MOTOR1_PIN           PB0


### PR DESCRIPTION
Adds missing USE_BARO_DPS310 define to NBD_GALAXYAIO255 target. 

Product page specifying DPS310 baro: https://newbeedrone.com/products/newbeedrone-galaxy-aio-255

Resolves: https://build.betaflight.com/api/support/c68a3481-7fdd-4a71-9238-8e723101742b