### PR TITLE
First submission of flight control board

### DIFF
--- a/configs/BAYCK_DOLPHIN_F435/config.h
+++ b/configs/BAYCK_DOLPHIN_F435/config.h
@@ -105,7 +105,6 @@
 #define ADC1_DMA_OPT        11
 
 #define MAG_I2C_INSTANCE (I2CDEV_1)
-#define USE_BARO
 #define BARO_SPI_INSTANCE SPI3
 #define USE_ADC
 #define ADC_INSTANCE ADC2
@@ -121,5 +120,3 @@
 #define GYRO_1_SPI_INSTANCE SPI1
 #define GYRO_1_ALIGN CW180_DEG
 #define GYRO_2_SPI_INSTANCE SPI1
-    
-    

--- a/configs/BAYCK_DOLPHIN_F435/config.h
+++ b/configs/BAYCK_DOLPHIN_F435/config.h
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     AT32F435G
+
+#define BOARD_NAME        BAYCK DOLPHIN
+#define MANUFACTURER_ID   BAYCKRC
+
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_MPU6500
+#define USE_ACC_SPI_ICM42688P
+
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_ICM42688P
+
+#define USE_BARO
+#define USE_BARO_SPI_BMP280
+
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_FLASH_W25N01G
+
+#define USE_MAX7456
+
+#define BEEPER_PIN           PB4
+#define MOTOR1_PIN           PB0
+#define MOTOR2_PIN           PB1
+#define MOTOR3_PIN           PA3
+#define MOTOR4_PIN           PB5
+#define MOTOR5_PIN           PC8
+#define MOTOR6_PIN           PC9
+#define RX_PPM_PIN           PB8
+#define LED_STRIP_PIN        PB6
+#define UART1_TX_PIN         PA9
+#define UART2_TX_PIN         PA2
+#define UART3_TX_PIN         PB10
+#define UART6_TX_PIN         PC6
+#define UART1_RX_PIN         PA10
+#define UART3_RX_PIN         PB11
+#define UART4_RX_PIN         PA1
+#define UART6_RX_PIN         PC7
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
+#define LED0_PIN             PA8
+#define SPI1_SCK_PIN         PA5
+#define SPI2_SCK_PIN         PB13
+#define SPI3_SCK_PIN         PC10
+#define SPI1_SDI_PIN         PA6
+#define SPI2_SDI_PIN         PB14
+#define SPI3_SDI_PIN         PC11
+#define SPI1_SDO_PIN         PA7
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SDO_PIN         PC12
+#define CAMERA_CONTROL_PIN   PB7
+#define ADC_VBAT_PIN         PC2
+#define ADC_RSSI_PIN         PA0
+#define ADC_CURR_PIN         PC1
+#define BARO_CS_PIN          PB3
+#define FLASH_CS_PIN         PB12
+#define MAX7456_SPI_CS_PIN   PA15
+#define GYRO_1_EXTI_PIN      PC4
+#define GYRO_2_EXTI_PIN      PC15
+#define GYRO_1_CS_PIN        PA4
+#define GYRO_2_CS_PIN        PC14
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB0 , 2,  7) \
+    TIMER_PIN_MAP( 1, PB1 , 2,  2) \
+    TIMER_PIN_MAP( 2, PA3 , 1,  6) \
+    TIMER_PIN_MAP( 3, PB5 , 1,  3) \
+    TIMER_PIN_MAP( 4, PC8 , 2,  9) \
+    TIMER_PIN_MAP( 5, PC9 , 2,  8) \
+    TIMER_PIN_MAP( 6, PB6 , 1,  13) \
+    TIMER_PIN_MAP( 7, PB8 , 2, -1) \
+    TIMER_PIN_MAP( 8, PC6 , 2,  11) \
+    TIMER_PIN_MAP( 9, PC7 , 2,  10) \
+    TIMER_PIN_MAP(10, PA9 , 1,  5) \
+    TIMER_PIN_MAP(11, PA10, 1,  4) \
+    TIMER_PIN_MAP(12, PA1 , 1,  12) \
+    TIMER_PIN_MAP(13, PA2 , 1, -1)
+
+#define ADC1_DMA_OPT        11
+
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define USE_BARO
+#define BARO_SPI_INSTANCE SPI3
+#define USE_ADC
+#define ADC_INSTANCE ADC2
+#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define BEEPER_INVERTED
+#define SYSTEM_HSE_MHZ 8
+#define MAX7456_SPI_INSTANCE SPI3
+#define DASHBOARD_I2C_INSTANCE (I2CDEV_1)
+#define FLASH_SPI_INSTANCE SPI2
+#define USE_SPI_GYRO
+#define GYRO_1_SPI_INSTANCE SPI1
+#define GYRO_1_ALIGN CW180_DEG
+#define GYRO_2_SPI_INSTANCE SPI1
+    
+    


### PR DESCRIPTION
This commit adds the BAYCK_DOLPHIN_F435 configuration file, which includes various settings and pin mappings for the target MCU AT32F435G. The configuration enables the use of accelerometer (ACC), gyroscope (GYRO), barometer (BARO), magnetometer (MAG), and MAX7456 OSD. It also defines pin assignments for motors, UARTs, LEDs, SPI interfaces, ADC pins, and timers. Additionally, it sets default values for blackbox device, current meter source and scale, voltage meter source and scale, and beeper inversion.
