### PR TITLE
AIRBOTF435-Fix led strip dma 

### DIFF
--- a/configs/AIRBOTF435/config.h
+++ b/configs/AIRBOTF435/config.h
@@ -105,7 +105,7 @@
 #define GYRO_1_CS_PIN                       PC14
 #define GYRO_1_SPI_INSTANCE                 SPI1
 
-#define TIMER_PIN_MAPPING                   TIMER_PIN_MAP( 0, LED_STRIP_PIN, 1, -1 ) \
+#define TIMER_PIN_MAPPING                   TIMER_PIN_MAP( 0, LED_STRIP_PIN, 1, 1 ) \
                                             TIMER_PIN_MAP( 1, MOTOR4_PIN, 1,  2 ) \
                                             TIMER_PIN_MAP( 2, MOTOR3_PIN, 1,  4 ) \
                                             TIMER_PIN_MAP( 3, MOTOR2_PIN, 2,  1 ) \


### PR DESCRIPTION
Dma pin for LED_STRIP is wrong asigned, it should use DMA 1.