### PR TITLE
Add baro define for NIDICI_F4 target

### DIFF
--- a/configs/NIDICI_F4/config.h
+++ b/configs/NIDICI_F4/config.h
@@ -32,6 +32,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
+#define USE_BARO_BMP280
 #define USE_MAX7456
 
 #define BEEPER_PIN           PB4


### PR DESCRIPTION
FC has BMP280 baro but was missing from config.

Reported by EZUD-77 on Discord, confirmed working here: https://discord.com/channels/868013470023548938/868013470518505494/1176517207015047208