### PR TITLE
Fix softserial resource on TUNERCF411

### DIFF
--- a/configs/TUNERCF411/config.h
+++ b/configs/TUNERCF411/config.h
@@ -43,7 +43,7 @@
 #define UART2_TX_PIN PA2
 #define UART1_RX_PIN PA10
 #define UART2_RX_PIN PA3
-#define UART1_TX_PIN PA8
+#define SOFTSERIAL1_TX_PIN PA8
 #define I2C1_SCL_PIN PB8
 #define I2C1_SDA_PIN PB9
 #define LED0_PIN PC13


### PR DESCRIPTION

Build fail
(TUNERCF411 / 4.5.0-zulu) [46.3.240.106 / 10.10.0-RC1].
Log: https://build.betaflight.com/api/builds/ac9263293036f32e72f786a06b119c08/log 
Request: https://build.betaflight.com/api/builds/ac9263293036f32e72f786a06b119c08/json 
--//-- [14.8]
