### PR TITLE
Add 42688 gyro to SKYSTARSH7HD

### DIFF
--- a/configs/SKYSTARSH7HD/config.h
+++ b/configs/SKYSTARSH7HD/config.h
@@ -29,6 +29,8 @@
 #define USE_GYRO
 #define USE_ACC
 #define USE_ACCGYRO_BMI270
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP280
 #define USE_FLASH


### PR DESCRIPTION
pls check, Michael says 42688 pin compatible to previous BMI270 so only added the defines...