### PR TITLE
Fix MatekF722HD baro not being detected

### DIFF
--- a/configs/MATEKF722HD/config.h
+++ b/configs/MATEKF722HD/config.h
@@ -30,6 +30,7 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_BARO
 #define USE_BARO_BMP280
 #define USE_BARO_DPS310
 #define USE_FLASH


### PR DESCRIPTION
This target had defines for BMP280 and DPS3210 baro's, but was missing the define to include Barometer, generally.