### PR TITLE
Fix typo in TIMER_PIN_MAP

### DIFF
--- a/configs/SPEEDYBEEF405MINI/config.h
+++ b/configs/SPEEDYBEEF405MINI/config.h
@@ -84,7 +84,7 @@
     TIMER_PIN_MAP( 3, PB0 , 2,  0) \
     TIMER_PIN_MAP( 4, PB14, 3, -1) \
     TIMER_PIN_MAP( 5, PA8 , 1,  0) \
-    TIMER_PIN_MAP( 9, PA3 , 3, -1)
+    TIMER_PIN_MAP( 6, PA3 , 3, -1)
 
 #define ADC1_DMA_OPT 0
 

--- a/configs/SPEEDYBEEF405MINI/config.h
+++ b/configs/SPEEDYBEEF405MINI/config.h
@@ -81,9 +81,9 @@
     TIMER_PIN_MAP( 0, PB6 , 1,  0) \
     TIMER_PIN_MAP( 1, PB7 , 1,  0) \
     TIMER_PIN_MAP( 2, PB1 , 2,  0) \
-    TIMER_PIN_MAP( 2, PB0 , 2,  0) \
-    TIMER_PIN_MAP( 3, PB14, 3, -1) \
-    TIMER_PIN_MAP( 4, PA8 , 1,  0) \
+    TIMER_PIN_MAP( 3, PB0 , 2,  0) \
+    TIMER_PIN_MAP( 4, PB14, 3, -1) \
+    TIMER_PIN_MAP( 5, PA8 , 1,  0) \
     TIMER_PIN_MAP( 9, PA3 , 3, -1)
 
 #define ADC1_DMA_OPT 0


### PR DESCRIPTION
Duplicated index n TIMER_PIN_MAP was preventing Motor 3 from being assigned a timer resource.