### PR TITLE
Enable bitbang on IFLIGHT_BLITZ_F435 by default

### DIFF
--- a/configs/IFLIGHT_BLITZ_F435/config.h
+++ b/configs/IFLIGHT_BLITZ_F435/config.h
@@ -45,7 +45,7 @@
 #define RX_PPM_PIN                      PA3
 
 #define DEFAULT_DSHOT_BURST             DSHOT_DMAR_AUTO
-#define DEFAULT_DSHOT_BITBANG           DSHOT_BITBANG_OFF
+#define DEFAULT_DSHOT_BITBANG           DSHOT_BITBANG_ON
 
 // SPI
 #define SPI1_SCK_PIN                    PA5


### PR DESCRIPTION
Enable DSHOT_BITBANG by default to fix RPM errors.