### PR TITLE
Add 42688 gyro to CrazyF405 Config

### DIFF
--- a/configs/CRAZYBEEF405/config.h
+++ b/configs/CRAZYBEEF405/config.h
@@ -28,6 +28,7 @@
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM42688P
 #define USE_ACCGYRO_BMI270
 #define USE_BARO
 #define USE_BARO_BMP280
@@ -35,6 +36,7 @@
 #define USE_FLASH_W25Q128FV
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM42688P
 #define USE_MAX7456
 
 #define BEEPER_PIN           PB4


### PR DESCRIPTION
The new SuperF405HD and Crux F405HD FCs from HM use the ICM42688p gyro, which is missing from the config. 

https://www.happymodel.cn/index.php/2024/01/05/super-f405hd-elrs-aio-3in1-flight-controller-built-in-uart-2-4g-elrs-and-20a-esc-for-hd-whoops-25-5x25-5mm-mount-hole/

https://www.happymodel.cn/index.php/2023/12/30/cruxf405hd-elrs-aio-3in1-flight-controller-built-in-uart-2-4g-elrs-and-20a-esc-for-toothpick-20mmx20mm-mount-hole/