### PR TITLE
SPRacingH7EXTREME/H7NANO/H7ZERO/H7RF - Compile-in LED strip by default.

### DIFF
--- a/configs/SPRACINGH7EXTREME/config.h
+++ b/configs/SPRACINGH7EXTREME/config.h
@@ -126,7 +126,11 @@
 #define USE_MAX7456
 #define USE_SDCARD
 #define USE_TRANSPONDER
+
+// The target has a specific set of pads for the LED strip.
+#ifndef USE_LED_STRIP
 #define USE_LED_STRIP
+#endif
 
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PA0

--- a/configs/SPRACINGH7EXTREME/config.h
+++ b/configs/SPRACINGH7EXTREME/config.h
@@ -126,6 +126,7 @@
 #define USE_MAX7456
 #define USE_SDCARD
 #define USE_TRANSPONDER
+#define USE_LED_STRIP
 
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PA0

--- a/configs/SPRACINGH7NANO/config.h
+++ b/configs/SPRACINGH7NANO/config.h
@@ -135,6 +135,7 @@
 #define USE_FLASH_W25N01G
 #define USE_CAMERA_CONTROL
 #define USE_MAX7456
+#define USE_LED_STRIP
 
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PA0

--- a/configs/SPRACINGH7NANO/config.h
+++ b/configs/SPRACINGH7NANO/config.h
@@ -135,7 +135,11 @@
 #define USE_FLASH_W25N01G
 #define USE_CAMERA_CONTROL
 #define USE_MAX7456
+
+// The target has a specific set of pads for the LED strip.
+#ifndef USE_LED_STRIP
 #define USE_LED_STRIP
+#endif
 
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PA0

--- a/configs/SPRACINGH7RF/config.h
+++ b/configs/SPRACINGH7RF/config.h
@@ -152,7 +152,11 @@
 #define USE_MAG_QMC5883
 #define USE_FLASH_W25Q128FV
 #define USE_SDCARD
+
+// The target has a connector and circuit for the LED strip.
+#ifndef USE_LED_STRIP
 #define USE_LED_STRIP
+#endif
 
 #ifndef USE_OSD
 #define USE_OSD

--- a/configs/SPRACINGH7RF/config.h
+++ b/configs/SPRACINGH7RF/config.h
@@ -152,6 +152,7 @@
 #define USE_MAG_QMC5883
 #define USE_FLASH_W25Q128FV
 #define USE_SDCARD
+#define USE_LED_STRIP
 
 #ifndef USE_OSD
 #define USE_OSD

--- a/configs/SPRACINGH7ZERO/config.h
+++ b/configs/SPRACINGH7ZERO/config.h
@@ -146,7 +146,11 @@
 #define USE_FLASH_W25N01G
 #define USE_CAMERA_CONTROL
 #define USE_MAX7456
+
+// The target has a specific set of pads for the LED strip.
+#ifndef USE_LED_STRIP
 #define USE_LED_STRIP
+#endif
 
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PA0

--- a/configs/SPRACINGH7ZERO/config.h
+++ b/configs/SPRACINGH7ZERO/config.h
@@ -146,6 +146,7 @@
 #define USE_FLASH_W25N01G
 #define USE_CAMERA_CONTROL
 #define USE_MAX7456
+#define USE_LED_STRIP
 
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PA0


### PR DESCRIPTION
The hardware has a pad specifically for LED strip.

![image](https://github.com/betaflight/config/assets/57075/265133ff-c68e-4764-afd3-d214562b69d9)

Without this users will be confused when the LED strip feature cannot be enabled.

Requires the following issue to be resolved https://github.com/betaflight/betaflight/issues/13438 which is fixed by https://github.com/betaflight/betaflight/pull/13439
