### PR TITLE
Update NEUTRONRCF407

### DIFF
--- a/configs/NEUTRONRCF407/config.h
+++ b/configs/NEUTRONRCF407/config.h
@@ -36,8 +36,8 @@
 #define USE_FLASH
 #define USE_FLASH_M25P16
 #define USE_MAX7456
+#define USE_BARO
 #define USE_BARO_DPS310
-#define USE_MAG_QMC5883
 
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB0
@@ -102,8 +102,6 @@
 
 #define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
 #define MAG_I2C_INSTANCE (I2CDEV_1)
-#define USE_MAG
-#define USE_BARO
 #define BARO_I2C_INSTANCE (I2CDEV_1)
 
 #define DEFAULT_DSHOT_BURST DSHOT_DMAR_ON

--- a/configs/NEUTRONRCF407/config.h
+++ b/configs/NEUTRONRCF407/config.h
@@ -38,6 +38,10 @@
 #define USE_MAX7456
 #define USE_BARO
 #define USE_BARO_DPS310
+#ifndef USE_MAG
+#define USE_MAG
+#define USE_MAG_QMC5883
+#endif
 
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB0


### PR DESCRIPTION
USE_MAG is a cloud build option. When user would try another compass current configuration would need to include custom defines for other compass drivers.