### PR TITLE
Fix Aocoda-RC H743Dual motor 5-8 mis-labeled issue

### DIFF
--- a/configs/AOCODARCH7DUAL/config.h
+++ b/configs/AOCODARCH7DUAL/config.h
@@ -46,10 +46,10 @@
 #define MOTOR2_PIN           PB1
 #define MOTOR3_PIN           PA0
 #define MOTOR4_PIN           PA1
-#define MOTOR5_PIN           PA2
-#define MOTOR6_PIN           PA3
-#define MOTOR7_PIN           PD12
-#define MOTOR8_PIN           PD13
+#define MOTOR5_PIN           PD13
+#define MOTOR6_PIN           PD12
+#define MOTOR7_PIN           PA3
+#define MOTOR8_PIN           PA2
 #define SERVO1_PIN           PE5
 #define SERVO2_PIN           PE6
 #define RX_PPM_PIN           PA10


### PR DESCRIPTION
[ Fix Aocoda-RC H743Dual motor 5-8 mis-labeled issue #9948 ](https://github.com/iNavFlight/inav/pull/9948)