### PR TITLE
Add flash to FPVM BetaflightF7

### DIFF
--- a/configs/FPVM_BETAFLIGHTF7/config.h
+++ b/configs/FPVM_BETAFLIGHTF7/config.h
@@ -33,6 +33,8 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_ACC_SPI_MPU6500
 #define USE_MAX7456
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
 
 #define BEEPER_PIN           PD15
 #define MOTOR1_PIN           PB0


### PR DESCRIPTION
FC includes Winbond 25Q128JVSQ flash, but define is missing from target.  https://www.getfpv.com/betaflight-f7-flight-controller.html