### PR TITLE
[github workflow] auto-close PR's with branch named 'master'

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -4,9 +4,6 @@ env:
 
 on:
   pull_request_target:
-    branches:
-      - master
-      - '*-maintenance'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -1,0 +1,25 @@
+name: Auto close bad PR
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+on:
+  pull_request_target:
+    branches:
+      - master
+      - '*-maintenance'
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  close-pr:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v4
+
+      - name: autoclose
+        shell: bash
+        if: github.head_ref == 'master'
+        run: gh pr close ${{github.event.pull_request.number}} --comment "Auto-closing pull request because the source branch is named 'master'. Please create a feature branch instead. https://betaflight.com/docs/development#using-git-and-github"


### PR DESCRIPTION
- this auto-closes PR's with branch named `master`
- tested on my fork via another fork
- **_caveat: repo setting must allow workflow runs even from first-time authors._**

![image](https://github.com/betaflight/config/assets/56646290/aa45cf59-8617-4810-b712-59894e891ff7)
