### PR TITLE
Add SPEEDYBEEH5DEV

### DIFF
--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -35,7 +35,6 @@
 #define USE_ACCGYRO_LSM6DSV16X
 
 #define GYRO_1_ALIGN                    CW90_DEG
-#define GYRO_1_ALIGN_YAW                900
 #define GYRO_1_EXTI_PIN                 PC4
 #define GYRO_1_CS_PIN                   PA4
 #define GYRO_1_SPI_INSTANCE             SPI1
@@ -67,8 +66,8 @@
 #define MOTOR6_PIN                      PC8
 #define MOTOR7_PIN                      PB11
 #define MOTOR8_PIN                      PB10
-#define MOTOR9_PIN                      PA1
-#define MOTOR10_PIN                     PA0
+#define SERVO1_PIN                      PA1
+#define SERVO2_PIN                      PA0
 
 #define LED_STRIP_PIN                   PA8
 
@@ -112,23 +111,23 @@
 #define ADC_RSSI_PIN                    PC2
 #define ADC_CURR_PIN                    PC1
 
-#define TIMER_PIN_MAPPING               TIMER_PIN_MAP(  0, MOTOR1_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  1, MOTOR2_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  2, MOTOR3_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  3, MOTOR4_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  4, MOTOR5_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  5, MOTOR6_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  6, MOTOR7_PIN, 1, 0 ) \
-                                        TIMER_PIN_MAP(  7, MOTOR8_PIN, 1, 0 ) \
-                                        TIMER_PIN_MAP(  8, MOTOR9_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP(  9, MOTOR10_PIN, 2, 0 ) \
-                                        TIMER_PIN_MAP( 10, LED_STRIP_PIN, 1, 0 ) \
+#define TIMER_PIN_MAPPING               TIMER_PIN_MAP(  0, MOTOR1_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP(  1, MOTOR2_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP(  2, MOTOR3_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP(  3, MOTOR4_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP(  4, MOTOR5_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP(  5, MOTOR6_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP(  6, MOTOR7_PIN, 1,  0 ) \
+                                        TIMER_PIN_MAP(  7, MOTOR8_PIN, 1,  0 ) \
+                                        TIMER_PIN_MAP(  8, SERVO1_PIN, 2, -1 ) \
+                                        TIMER_PIN_MAP(  9, SERVO2_PIN, 2, -1 ) \
+                                        TIMER_PIN_MAP( 10, LED_STRIP_PIN, 1,  0 ) \
                                         TIMER_PIN_MAP( 11, CAMERA_CONTROL_PIN, 2, -1 )
 
 #define ADC1_DMA_OPT                    0
 
-#define MAG_I2C_INSTANCE                (I2CDEV_1)
-#define BARO_I2C_INSTANCE               (I2CDEV_1)
+#define MAG_I2C_INSTANCE                I2CDEV_1
+#define BARO_I2C_INSTANCE               I2CDEV_1
 #define DEFAULT_BLACKBOX_DEVICE         BLACKBOX_DEVICE_SDCARD
 #define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
 #define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC

--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -112,17 +112,18 @@
 #define ADC_RSSI_PIN                    PC2
 #define ADC_CURR_PIN                    PC1
 
-#define TIMER_PIN_MAPPING               TIMER_PIN_MAP(0, MOTOR1_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(1, MOTOR2_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(2, MOTOR3_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(3, MOTOR4_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(4, MOTOR5_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(5, MOTOR6_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(6, MOTOR7_PIN, 1, 0) \
-                                        TIMER_PIN_MAP(7, MOTOR8_PIN, 1, 0) \
-                                        TIMER_PIN_MAP(8, MOTOR9_PIN, 2, 0) \
-                                        TIMER_PIN_MAP(9, MOTOR10_PIN, 2, 0 \
-                                        TIMER_PIN_MAP(10, LED_STRIP_PIN, 1, 0)
+#define TIMER_PIN_MAPPING               TIMER_PIN_MAP(  0, MOTOR1_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  1, MOTOR2_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  2, MOTOR3_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  3, MOTOR4_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  4, MOTOR5_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  5, MOTOR6_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  6, MOTOR7_PIN, 1, 0 ) \
+                                        TIMER_PIN_MAP(  7, MOTOR8_PIN, 1, 0 ) \
+                                        TIMER_PIN_MAP(  8, MOTOR9_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP(  9, MOTOR10_PIN, 2, 0 ) \
+                                        TIMER_PIN_MAP( 10, LED_STRIP_PIN, 1, 0 ) \
+                                        TIMER_PIN_MAP( 11, CAMERA_CONTROL_PIN, 2, -1 )
 
 #define ADC1_DMA_OPT                    0
 

--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -112,6 +112,18 @@
 #define ADC_RSSI_PIN                    PC2
 #define ADC_CURR_PIN                    PC1
 
+#define TIMER_PIN_MAPPING               TIMER_PIN_MAP(0, MOTOR1_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(1, MOTOR2_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(2, MOTOR3_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(3, MOTOR4_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(4, MOTOR5_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(5, MOTOR6_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(6, MOTOR7_PIN, 1, 0) \
+                                        TIMER_PIN_MAP(7, MOTOR8_PIN, 1, 0) \
+                                        TIMER_PIN_MAP(8, MOTOR9_PIN, 2, 0) \
+                                        TIMER_PIN_MAP(9, MOTOR10_PIN, 2, 0 \
+                                        TIMER_PIN_MAP(10, LED_STRIP_PIN, 1, 0)
+
 #define ADC1_DMA_OPT                    0
 
 #define MAG_I2C_INSTANCE                (I2CDEV_1)

--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -1,0 +1,127 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// Support for STM32H5xx is under development
+// This target is not yet supported in the official Betaflight releases
+
+#pragma once
+
+#define FC_TARGET_MCU                   STM32H563
+
+#define BOARD_NAME                      SPEEDYBEEH5
+#define MANUFACTURER_ID                 SPBE
+
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACCGYRO_LSM6DSV16X
+
+#define GYRO_1_ALIGN                    CW90_DEG
+#define GYRO_1_ALIGN_YAW                900
+#define GYRO_1_EXTI_PIN                 PC4
+#define GYRO_1_CS_PIN                   PA4
+#define GYRO_1_SPI_INSTANCE             SPI1
+
+#define USE_MAX7456
+#define MAX7456_SPI_CS_PIN              PB12
+#define MAX7456_SPI_INSTANCE            SPI2
+
+#define USE_SDCARD
+#define SDCARD_DETECT_INVERTED
+#define USE_SDCARD_SPI
+#define SDCARD_SPI_CS_PIN               PC12
+#define SDCARD_SPI_INSTANCE             SPI3
+
+#define USE_BARO
+#define USE_BARO_LPS22DF
+
+#define SWDIO_PIN                       PA13
+#define SWCLK_PIN                       PA14
+
+#define BEEPER_INVERTED
+#define BEEPER_PIN                      PA15
+
+#define MOTOR1_PIN                      PB6
+#define MOTOR2_PIN                      PB7
+#define MOTOR3_PIN                      PB0
+#define MOTOR4_PIN                      PB1
+#define MOTOR5_PIN                      PC9
+#define MOTOR6_PIN                      PC8
+#define MOTOR7_PIN                      PB11
+#define MOTOR8_PIN                      PB10
+#define MOTOR9_PIN                      PA1
+#define MOTOR10_PIN                     PA0
+
+#define LED_STRIP_PIN                   PA8
+
+#define UART1_TX_PIN                    PA9
+#define UART1_RX_PIN                    PA10
+
+#define UART2_TX_PIN                    PA2
+#define UART2_RX_PIN                    PA3
+
+#define UART3_TX_PIN                    PC10
+#define UART3_RX_PIN                    PC11
+
+#define UART4_TX_PIN                    PD12
+#define UART4_RX_PIN                    PD11
+
+#define UART6_TX_PIN                    PC6
+#define UART6_RX_PIN                    PC7
+
+#define UART8_RX_PIN                    PE0
+
+#define I2C1_SCL_PIN                    PB8
+#define I2C1_SDA_PIN                    PB9
+
+#define LED0_PIN                        PC3
+
+#define SPI1_SCK_PIN                    PA5
+#define SPI1_SDI_PIN                    PA6
+#define SPI1_SDO_PIN                    PA7
+
+#define SPI2_SCK_PIN                    PB13
+#define SPI2_SDI_PIN                    PC2
+#define SPI2_SDO_PIN                    PC3
+
+#define SPI3_SCK_PIN                    PB3
+#define SPI3_SDI_PIN                    PB4
+#define SPI3_SDO_PIN                    PB5
+
+#define CAMERA_CONTROL_PIN              PA0
+
+#define ADC_VBAT_PIN                    PC0
+#define ADC_RSSI_PIN                    PC2
+#define ADC_CURR_PIN                    PC1
+
+#define ADC1_DMA_OPT                    0
+
+#define MAG_I2C_INSTANCE                (I2CDEV_1)
+#define BARO_I2C_INSTANCE               (I2CDEV_1)
+#define DEFAULT_BLACKBOX_DEVICE         BLACKBOX_DEVICE_SDCARD
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE     400
+#define SYSTEM_HSE_MHZ                  8
+
+#define SERIALRX_UART                   SERIAL_PORT_USART2
+#define MSP_UART                        SERIAL_PORT_UART4
+#define ESC_SENSOR_UART                 SERIAL_PORT_UART8

--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -66,7 +66,6 @@
 #define MOTOR6_PIN                      PC8
 #define MOTOR7_PIN                      PB11
 #define MOTOR8_PIN                      PB10
-#define SERVO1_PIN                      PA1
 
 #define LED_STRIP_PIN                   PA8
 
@@ -110,18 +109,16 @@
 #define ADC_RSSI_PIN                    PC2
 #define ADC_CURR_PIN                    PC1
 
-#define TIMER_PIN_MAPPING               TIMER_PIN_MAP(  0, MOTOR1_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  1, MOTOR2_PIN, 2,  1 ) \
-                                        TIMER_PIN_MAP(  2, MOTOR3_PIN, 2,  2 ) \
-                                        TIMER_PIN_MAP(  3, MOTOR4_PIN, 2,  3 ) \
-                                        TIMER_PIN_MAP(  4, MOTOR5_PIN, 2,  4 ) \
-                                        TIMER_PIN_MAP(  5, MOTOR6_PIN, 2,  5 ) \
-                                        TIMER_PIN_MAP(  6, MOTOR7_PIN, 1,  6 ) \
-                                        TIMER_PIN_MAP(  7, MOTOR8_PIN, 1,  7 ) \
-                                        TIMER_PIN_MAP(  8, SERVO1_PIN, 2, -1 ) \
-                                        TIMER_PIN_MAP(  9, SERVO2_PIN, 2, -1 ) \
-                                        TIMER_PIN_MAP( 10, LED_STRIP_PIN, 1,  8 ) \
-                                        TIMER_PIN_MAP( 11, CAMERA_CONTROL_PIN, 2, -1 )
+#define TIMER_PIN_MAPPING               TIMER_PIN_MAP( 0, MOTOR1_PIN, 2,  0 ) \
+                                        TIMER_PIN_MAP( 1, MOTOR2_PIN, 2,  1 ) \
+                                        TIMER_PIN_MAP( 2, MOTOR3_PIN, 2,  2 ) \
+                                        TIMER_PIN_MAP( 3, MOTOR4_PIN, 2,  3 ) \
+                                        TIMER_PIN_MAP( 4, MOTOR5_PIN, 2,  4 ) \
+                                        TIMER_PIN_MAP( 5, MOTOR6_PIN, 2,  5 ) \
+                                        TIMER_PIN_MAP( 6, MOTOR7_PIN, 1,  6 ) \
+                                        TIMER_PIN_MAP( 7, MOTOR8_PIN, 1,  7 ) \
+                                        TIMER_PIN_MAP( 8, LED_STRIP_PIN, 1,  8 ) \
+                                        TIMER_PIN_MAP( 9, CAMERA_CONTROL_PIN, 2, -1 )
 
 // H5 routes internal channels to both ADC1 (VREFINT/TEMPSENSOR) and ADC2
 // (VBAT/4), so each ADC in use needs a valid GPDMA option. opt 0-7 = GPDMA1

--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -112,19 +112,24 @@
 #define ADC_CURR_PIN                    PC1
 
 #define TIMER_PIN_MAPPING               TIMER_PIN_MAP(  0, MOTOR1_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  1, MOTOR2_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  2, MOTOR3_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  3, MOTOR4_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  4, MOTOR5_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  5, MOTOR6_PIN, 2,  0 ) \
-                                        TIMER_PIN_MAP(  6, MOTOR7_PIN, 1,  0 ) \
-                                        TIMER_PIN_MAP(  7, MOTOR8_PIN, 1,  0 ) \
+                                        TIMER_PIN_MAP(  1, MOTOR2_PIN, 2,  1 ) \
+                                        TIMER_PIN_MAP(  2, MOTOR3_PIN, 2,  2 ) \
+                                        TIMER_PIN_MAP(  3, MOTOR4_PIN, 2,  3 ) \
+                                        TIMER_PIN_MAP(  4, MOTOR5_PIN, 2,  4 ) \
+                                        TIMER_PIN_MAP(  5, MOTOR6_PIN, 2,  5 ) \
+                                        TIMER_PIN_MAP(  6, MOTOR7_PIN, 1,  6 ) \
+                                        TIMER_PIN_MAP(  7, MOTOR8_PIN, 1,  7 ) \
                                         TIMER_PIN_MAP(  8, SERVO1_PIN, 2, -1 ) \
                                         TIMER_PIN_MAP(  9, SERVO2_PIN, 2, -1 ) \
-                                        TIMER_PIN_MAP( 10, LED_STRIP_PIN, 1,  0 ) \
+                                        TIMER_PIN_MAP( 10, LED_STRIP_PIN, 1,  8 ) \
                                         TIMER_PIN_MAP( 11, CAMERA_CONTROL_PIN, 2, -1 )
 
-#define ADC1_DMA_OPT                    0
+// H5 routes internal channels to both ADC1 (VREFINT/TEMPSENSOR) and ADC2
+// (VBAT/4), so each ADC in use needs a valid GPDMA option. opt 0-7 = GPDMA1
+// ch0-7, opt 8-15 = GPDMA2 ch0-7; ADC is placed on GPDMA2 to stay clear of
+// motor/timer DMA on GPDMA1.
+#define ADC1_DMA_OPT                    9
+#define ADC2_DMA_OPT                    10
 
 #define MAG_I2C_INSTANCE                I2CDEV_1
 #define BARO_I2C_INSTANCE               I2CDEV_1

--- a/configs/SPEEDYBEEH5/config.h
+++ b/configs/SPEEDYBEEH5/config.h
@@ -67,7 +67,6 @@
 #define MOTOR7_PIN                      PB11
 #define MOTOR8_PIN                      PB10
 #define SERVO1_PIN                      PA1
-#define SERVO2_PIN                      PA0
 
 #define LED_STRIP_PIN                   PA8
 
@@ -98,8 +97,8 @@
 #define SPI1_SDO_PIN                    PA7
 
 #define SPI2_SCK_PIN                    PB13
-#define SPI2_SDI_PIN                    PC2
-#define SPI2_SDO_PIN                    PC3
+#define SPI2_SDI_PIN                    PB14
+#define SPI2_SDO_PIN                    PB15
 
 #define SPI3_SCK_PIN                    PB3
 #define SPI3_SDI_PIN                    PB4

--- a/configs/SPEEDYBEEH5DEV/config.h
+++ b/configs/SPEEDYBEEH5DEV/config.h
@@ -27,7 +27,7 @@
 
 #define FC_TARGET_MCU                   STM32H563
 
-#define BOARD_NAME                      SPEEDYBEEH5
+#define BOARD_NAME                      SPEEDYBEEH5DEV
 #define MANUFACTURER_ID                 SPBE
 
 #define USE_ACC


### PR DESCRIPTION
This target is still in development so does not compile currently.
- note CC and SERVO are mutually exclusive

IDX | PIN | RESOURCE | TIMER | DMA
---: | --- | --- | --- | ---:
0 | PB6 | MOTOR1_PIN | TIM4_CH1 | 0 
1 | PB7 | MOTOR2_PIN | TIM4_CH2 | 0
2 | PB0 | MOTOR3_PIN | TIM3_CH3 | 0
3 | PB1 | MOTOR4_PIN | TIM3_CH4 | 0
4 | PC9 | MOTOR5_PIN | TIM8_CH4 | 0
5 | PC8 | MOTOR6_PIN | TIM8_CH3 | 0
6 | PB11 | MOTOR7_PIN | TIM2_CH4 | 0
7 | PB10 | MOTOR8_PIN | TIM2_CH3 | 0
8 | PA8 | LED_STRIP_PIN | TIM1_CH1 | 0
9 | PA0 | CAMERA_CONTROL_PIN | TIM5_CH1 | -1

Timer specs: https://github.com/betaflight/betaflight/pull/13685

### Status

MCU: STM32H563xx CLK=250MHz, Vref=3.26V, Core temp=37degC
STACK: 2048b (0x2009fff8)
CONFIG: CONFIGURED (4259b / 131072b)

DEVICES DETECTED: SPI=1, I2C=1 (0 errors)
GYRO: (1) LSM6DSV16X enabled locked dma
ACC: LSM6DSV16X
BARO: LPS22DF
GPS: NOT ENABLED
OSD: MSP (53 x 20)
SD-CARD: Manufacturer 0x3, 31166976kB, 01/2022, v8.5, 'SD32G FS: Ready

System Uptime: 38 seconds, Current Time: 2026-06-03T12:27:09.474+00:00
CPU:49%, cycle time: 135, GYRO rate: 7407, RX rate: 0, System rate: 9
Voltage: 0.00V (0S battery - NOT PRESENT)
Arming disable flags: RXLOSS ANGLE CLI MSP

### Support ID

`d65abae7-dbd9-478b-b8a6-41583778f0bc`

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the under-development SPEEDYBEEH5DEV STM32H5 flight controller target.
  * Enabled onboard accelerometer, gyroscope, barometer, video overlay, SD card, motor, LED, camera, and telemetry capabilities.
  * Added configured serial, SPI, I2C, ADC, and sensor interfaces for the board.
  * Added default blackbox logging and voltage/current monitoring support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->