### PR TITLE
Add CCRCF722D

### DIFF
--- a/configs/CCRCF722D/config.h
+++ b/configs/CCRCF722D/config.h
@@ -1,0 +1,119 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32F7X2
+
+#define BOARD_NAME        CCRCF722D
+#define MANUFACTURER_ID   CCRC
+
+#define USE_GYRO
+#define USE_ACC
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
+#define BEEPER_PIN           PC13
+#define MOTOR1_PIN           PC8
+#define MOTOR2_PIN           PC9
+#define MOTOR3_PIN           PA8
+#define MOTOR4_PIN           PA9
+#define MOTOR5_PIN           PB0
+#define MOTOR6_PIN           PB1
+#define MOTOR7_PIN           PA10
+#define MOTOR8_PIN           PB4
+#define LED_STRIP_PIN        PB3
+#define UART1_TX_PIN         PB6
+#define UART2_TX_PIN         PA2
+#define UART4_TX_PIN         PA0
+#define UART5_TX_PIN         PC12
+#define UART6_TX_PIN         PC6
+#define UART1_RX_PIN         PB7
+#define UART2_RX_PIN         PA3
+#define UART3_RX_PIN         PB11
+#define UART4_RX_PIN         PA1
+#define UART5_RX_PIN         PD2
+#define UART6_RX_PIN         PC7
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
+#define LED0_PIN             PC14
+#define LED1_PIN             PC15
+#define SPI1_SCK_PIN         PA5
+#define SPI2_SCK_PIN         PB13
+#define SPI3_SCK_PIN         PC10
+#define SPI1_SDI_PIN         PA6
+#define SPI2_SDI_PIN         PB14
+#define SPI3_SDI_PIN         PC11
+#define SPI1_SDO_PIN         PA7
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SDO_PIN         PB5
+#define ADC_VBAT_PIN         PC1
+#define ADC_CURR_PIN         PC3
+#define PINIO1_PIN           PC0
+#define PINIO2_PIN           PC2
+#define FLASH_CS_PIN         PA15
+#define MAX7456_SPI_CS_PIN   PB12
+#define GYRO_1_EXTI_PIN      PC4
+#define GYRO_2_EXTI_PIN      PB10
+#define GYRO_1_CS_PIN        PA4
+#define GYRO_2_CS_PIN        PB2
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PC8 , 2,  0) \
+    TIMER_PIN_MAP( 1, PC9 , 2,  0) \
+    TIMER_PIN_MAP( 2, PA8 , 1,  0) \
+    TIMER_PIN_MAP( 3, PA9 , 1,  0) \
+    TIMER_PIN_MAP( 4, PB0 , 2,  0) \
+    TIMER_PIN_MAP( 5, PB1 , 2,  0) \
+    TIMER_PIN_MAP( 6, PA10, 1,  0) \
+    TIMER_PIN_MAP( 7, PB4 , 1,  0) \
+    TIMER_PIN_MAP( 8, PB3 , 1,  0)
+
+
+#define ADC3_DMA_OPT        0
+
+#define DEFAULT_GYRO_TO_USE GYRO_CONFIG_USE_GYRO_BOTH
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define USE_BARO
+#define BARO_I2C_INSTANCE (I2CDEV_1)
+#define ADC_INSTANCE ADC3
+#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
+#define DEFAULT_DSHOT_BURST DSHOT_DMAR_ON
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE 250
+#define BEEPER_INVERTED
+#define MAX7456_SPI_INSTANCE SPI2
+#define PINIO1_CONFIG 129
+#define PINIO2_CONFIG 129
+#define PINIO1_BOX 40
+#define PINIO2_BOX 41
+#define FLASH_SPI_INSTANCE SPI3
+#define GYRO_1_SPI_INSTANCE SPI1
+#define GYRO_1_ALIGN CW270_DEG
+#define GYRO_1_ALIGN_YAW 2700
+#define GYRO_2_SPI_INSTANCE SPI1
+#define GYRO_2_ALIGN CW270_DEG
+#define GYRO_2_ALIGN_YAW 2700


### PR DESCRIPTION
It's a dual ICM42688 gyro FC with F722 MCU, analog osd, 5/10V BEC, 16MB blackbox, DPS310 baro.
![IMG_20240531_111520](https://github.com/betaflight/config/assets/62965528/756db3d8-4f6c-41ad-93dc-d6d0cf490a5d)
![IMG_20240531_111537](https://github.com/betaflight/config/assets/62965528/2871be79-e946-4f33-a0bb-507d60b5a7bd)
