### PR TITLE
Update HGLRCF405V2/config.h

### DIFF
--- a/configs/HGLRCF405V2/config.h
+++ b/configs/HGLRCF405V2/config.h
@@ -27,6 +27,7 @@
 
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
+#define USE_ACC_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP280
 #define USE_BARO_DPS310
@@ -34,6 +35,7 @@
 #define USE_FLASH_W25Q128FV
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_GYRO_SPI_ICM42688P
 #define USE_MAX7456
 
 #define BEEPER_PIN PB8


### PR DESCRIPTION
The latest FC contains the ICM42688P gyroscope, but the target lacks definitions. Add ICM42688P definitions