### PR TITLE
add TUNERCF435

### DIFF
--- a/configs/TUNERCF435/config.h
+++ b/configs/TUNERCF435/config.h
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU        AT32F435G
+
+#define BOARD_NAME           TUNERCF435
+#define MANUFACTURER_ID      TURC
+
+#define USE_ACC
+#define USE_GYRO
+
+#define USE_ACCGYRO_BMI270
+
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
+
+#define USE_BARO
+#define USE_BARO_DPS310
+
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+
+#define USE_MAX7456
+
+#define USE_BEEPER
+#define BEEPER_PIN              PC15
+
+#define MOTOR1_PIN              PB6
+#define MOTOR2_PIN              PB7
+#define MOTOR3_PIN              PA3
+#define MOTOR4_PIN              PB1
+
+#define LED_STRIP_PIN           PA8
+
+#define UART1_TX_PIN            PA9
+#define UART2_TX_PIN            PA2
+#define UART3_TX_PIN            PB11
+#define UART5_TX_PIN            PB9
+#define UART7_TX_PIN            PB4
+#define UART1_RX_PIN            PA10
+#define UART2_RX_PIN            PB0
+#define UART3_RX_PIN            PB10
+#define UART5_RX_PIN            PB8
+#define UART7_RX_PIN            PB3
+#define INVERTER_PIN_UART5		PC13
+#define I2C2_SCL_PIN            PH2
+#define I2C2_SDA_PIN            PH3
+#define LED0_PIN                PC14
+#define SPI1_SCK_PIN            PA5
+#define SPI2_SCK_PIN            PB13
+#define SPI1_SDI_PIN            PA6
+#define SPI2_SDI_PIN            PB14
+#define SPI1_SDO_PIN            PA7
+#define SPI2_SDO_PIN            PB15
+#define FLASH_CS_PIN            PB5
+#define MAX7456_SPI_CS_PIN      PB12
+#define GYRO_1_EXTI_PIN         PA15
+#define GYRO_1_CS_PIN           PA4
+
+#define ADC_VBAT_PIN            PA0
+#define ADC_CURR_PIN            PA1
+#define ADC_INSTANCE            ADC1
+#define ADC1_DMA_OPT            11
+
+#define TIMER_PIN_MAPPING       TIMER_PIN_MAP(0, PA8, 1, 7) \
+                                TIMER_PIN_MAP(1, PB6, 1, 0) \
+                                TIMER_PIN_MAP(2, PB7, 1, 1) \
+                                TIMER_PIN_MAP(3, PA3, 1, 2) \
+                                TIMER_PIN_MAP(4, PB1, 2, 3)
+
+#define DEFAULT_BLACKBOX_DEVICE BLACKBOX_DEVICE_FLASH
+#define DEFAULT_DSHOT_BURST DSHOT_DMAR_AUTO
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define BEEPER_INVERTED
+#define SYSTEM_HSE_MHZ          8
+#define GYRO_1_SPI_INSTANCE     SPI1
+#define GYRO_1_ALIGN CW270_DEG
+#define GYRO_1_ALIGN_YAW 2700
+#define MAX7456_SPI_INSTANCE    SPI2
+#define FLASH_SPI_INSTANCE      SPI2
+#define BARO_I2C_INSTANCE       (I2CDEV_2)


### PR DESCRIPTION
Hello Betaflight Developers,

We provided samples of this AT32 FC before to the team before. A few changes were made on the official version of this FC. Detailed changes are listed below.

1. All of the connectors are moved to the bottom side of the FC and soldering pads are added to the top side of the FC.

2. Our company logo, model number, product name, orientation arrow and the soldering pad silkscreens are added to the official version.

3. The height of the power inductor is decreased from 3mm to 1.8mm.

4. The barometer model is changed from BMP280 to DPS310.
5. One LED is removed from the board (total number of the LED is changed from 3 to 2)

This FC will be put into mass production recently, we can provide production version samples to the developers if needed.

The first batch of samples is on the left, and the second batch is on the right.
![noodle](https://github.com/betaflight/config/assets/71423100/6bf19408-dc9c-4442-b740-92aea3ae23ce)
