### PR TITLE
TMOTORF7/TMOTORF7_AIO - Fix incorrect timer assignment

### DIFF
--- a/configs/TMOTORF7/config.h
+++ b/configs/TMOTORF7/config.h
@@ -89,7 +89,7 @@
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PC6 , 1,  0) \
     TIMER_PIN_MAP( 1, PC7 , 1,  0) \
-    TIMER_PIN_MAP( 2, PB0 , 3,  0) \
+    TIMER_PIN_MAP( 2, PB0 , 2,  0) \
     TIMER_PIN_MAP( 3, PB1 , 2,  0) \
     TIMER_PIN_MAP( 4, PB6 , 1,  0) \
     TIMER_PIN_MAP( 5, PB8 , 1,  0) \

--- a/configs/TMOTORF7_AIO/config.h
+++ b/configs/TMOTORF7_AIO/config.h
@@ -83,7 +83,7 @@
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PC6 , 1,  0) \
     TIMER_PIN_MAP( 1, PC7 , 1,  0) \
-    TIMER_PIN_MAP( 2, PB0 , 3,  0) \
+    TIMER_PIN_MAP( 2, PB0 , 2,  0) \
     TIMER_PIN_MAP( 3, PB1 , 2,  0) \
     TIMER_PIN_MAP( 4, PB6 , 1,  0) \
     TIMER_PIN_MAP( 5, PB8 , 1,  0) \


### PR DESCRIPTION
Motor 3 was set to AF3 (TIM8_CH3N) for some reason.

Discussion on BF Discord here: https://discord.com/channels/868013470023548938/924169080045445120/1265379403429314691