### PR TITLE
Fix timers definition for FREEAXISF4 config.h.

### DIFF
--- a/configs/FREEAXISF4/config.h
+++ b/configs/FREEAXISF4/config.h
@@ -68,10 +68,10 @@
 
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PA3 , 3, -1) \
-    TIMER_PIN_MAP( 1, PB4 , 2,  0) \
-    TIMER_PIN_MAP( 2, PB5 , 2,  0) \
-    TIMER_PIN_MAP( 3, PB6 , 2,  0) \
-    TIMER_PIN_MAP( 4, PB7 , 2,  0) \
+    TIMER_PIN_MAP( 1, PB4 , 1,  0) \
+    TIMER_PIN_MAP( 2, PB5 , 1,  0) \
+    TIMER_PIN_MAP( 3, PB6 , 1,  0) \
+    TIMER_PIN_MAP( 4, PB7 , 1,  0) \
     TIMER_PIN_MAP( 5, PB3 , 1,  0) \
     TIMER_PIN_MAP( 6, PB10, 1,  0) \
     TIMER_PIN_MAP( 7, PA0 , 2,  0) \

--- a/configs/FREEAXISF4/config.h
+++ b/configs/FREEAXISF4/config.h
@@ -67,16 +67,13 @@
 #define USB_DETECT_PIN       PC15
 
 #define TIMER_PIN_MAPPING \
-    TIMER_PIN_MAP( 0, PA3 , 3, -1) \
-    TIMER_PIN_MAP( 1, PB4 , 1,  0) \
-    TIMER_PIN_MAP( 2, PB5 , 1,  0) \
-    TIMER_PIN_MAP( 3, PB6 , 1,  0) \
-    TIMER_PIN_MAP( 4, PB7 , 1,  0) \
-    TIMER_PIN_MAP( 5, PB3 , 1,  0) \
-    TIMER_PIN_MAP( 6, PB10, 1,  0) \
-    TIMER_PIN_MAP( 7, PA0 , 2,  0) \
-    TIMER_PIN_MAP( 8, PA2 , 2,  0) \
-    TIMER_PIN_MAP( 9, PA8 , 1,  0)
+    TIMER_PIN_MAP( 0, PB4 , 1, 0 ) \
+    TIMER_PIN_MAP( 1, PB5 , 1, 0 ) \
+    TIMER_PIN_MAP( 2, PB6 , 1, 0 ) \
+    TIMER_PIN_MAP( 3, PB7 , 1, 0 ) \
+    TIMER_PIN_MAP( 4, PB3 , 1, 0 ) \
+    TIMER_PIN_MAP( 5, PB10, 1, 0 ) \
+    TIMER_PIN_MAP( 6, PA8 , 1, 0 )
 
 #define ADC1_DMA_OPT        1
 


### PR DESCRIPTION
Fix: "No motor outputs found"
Update timers definition to be inline with config from unified-targets repo. 