### PR TITLE
Update MLTYPHF4/config.h with spi vtx RTC6705 support

### DIFF
--- a/configs/MLTYPHF4/config.h
+++ b/configs/MLTYPHF4/config.h
@@ -72,7 +72,6 @@
 #define RTC6705_SPICLK_PIN   PC2
 #define RTC6705_CS_PIN       PC7
 
-
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PB5 , 1,  0) \
     TIMER_PIN_MAP( 1, PB0 , 2,  0) \

--- a/configs/MLTYPHF4/config.h
+++ b/configs/MLTYPHF4/config.h
@@ -31,6 +31,7 @@
 #define USE_ACC
 #define USE_ACC_SPI_MPU6000
 #define USE_MAX7456
+#define USE_VTX_RTC6705_SOFTSPI
 
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB5
@@ -67,6 +68,10 @@
 #define VTX_CS_PIN           PC7
 #define VTX_DATA_PIN         PC6
 #define VTX_CLK_PIN          PC2
+#define RTC6705_SPI_SDO_PIN  PC6
+#define RTC6705_SPICLK_PIN   PC2
+#define RTC6705_CS_PIN       PC7
+
 
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PB5 , 1,  0) \


### PR DESCRIPTION
The Motolabs Typhoon F4 stack's VTX connects via RTC6705. The pins for this were defined in it's config, but named differently for unknown reasons. 

This adds defines for the correct variable names as well as declaring it's necessary include. 

Works with both full and cloud builds.

As seen in: https://discord.com/channels/868013470023548938/1269705725685399666

## Pull-Request requirements
- Adhere to https://betaflight.com/docs/development/manufacturer/requirements-for-submission-of-targets.
  AND https://betaflight.com/docs/development/manufacturer/config-target-guidance
- Pull-Request only from a custom branch, not `master`.
- Replace this text with details of your own.