### PR TITLE
RRIOT_F722 - fix pinio to control VTX instead of PIT MODE

### DIFF
--- a/configs/RRIOT_F722/config.h
+++ b/configs/RRIOT_F722/config.h
@@ -99,5 +99,4 @@
 
 #define BEEPER_INVERTED
 
-#define PINIO1_PIN PB0
-#define PINIO1_BOX 39
+#define PINIO1_BOX 40


### PR DESCRIPTION
https://discord.com/channels/868013470023548938/1256215237879664672/1270436169309749370

We had pinio set up to control PIT MODE instead of the correct VTX control. This powers the VTX by default.