### PR TITLE
Fix MAMBAF405_I2C DMA assignments

### DIFF
--- a/configs/MAMBAF405US_I2C/config.h
+++ b/configs/MAMBAF405US_I2C/config.h
@@ -30,6 +30,7 @@
 #define USE_ACC_SPI_MPU6000
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
+#define USE_BARO
 #define USE_BARO_BMP280
 #define USE_FLASH
 #define USE_FLASH_M25P16
@@ -39,13 +40,12 @@
 #define LED1_PIN             PC14
 #define BEEPER_PIN           PC13
 #define BEEPER_INVERTED
-//TODO #define OSD_DISPLAYPORT_DEVICE MAX7456
 
 #define GYRO_1_EXTI_PIN      PC4
 #define GYRO_1_CS_PIN        PA4
-#define GYRO_1_SPI_INSTANCE SPI1
-#define GYRO_1_ALIGN CW180_DEG
-#define GYRO_1_ALIGN_YAW 1800
+#define GYRO_1_SPI_INSTANCE  SPI1
+#define GYRO_1_ALIGN         CW180_DEG
+#define GYRO_1_ALIGN_YAW     1800
 
 #define SPI1_SCK_PIN         PA5
 #define SPI1_SDI_PIN         PA6
@@ -60,7 +60,7 @@
 #define SPI3_SDO_PIN         PB5
 
 #define FLASH_CS_PIN         PA15
-#define FLASH_SPI_INSTANCE SPI3
+#define FLASH_SPI_INSTANCE   SPI3
 
 #define MAX7456_SPI_CS_PIN   PB12
 #define MAX7456_SPI_INSTANCE SPI2
@@ -68,7 +68,7 @@
 #define ADC_VBAT_PIN         PC1
 #define ADC_RSSI_PIN         PC2
 #define ADC_CURR_PIN         PC3
-#define ADC_INSTANCE ADC3
+#define ADC_INSTANCE         ADC3
 
 #define UART1_TX_PIN         PB6
 #define UART1_RX_PIN         PB7
@@ -92,13 +92,11 @@
 #define I2C1_SDA_PIN         PB9
 
 #define TIMER_PIN_MAPPING \
-    TIMER_PIN_MAP( 0, PB9 , 2, -1) \
-    TIMER_PIN_MAP( 1, PA9 , 1,  0) \
-    TIMER_PIN_MAP( 2, PA8 , 1,  0) \
-    TIMER_PIN_MAP( 3, PC9 , 2,  0) \
-    TIMER_PIN_MAP( 4, PC8 , 2,  0) \
-    TIMER_PIN_MAP( 5, PB8 , 1,  0) \
-    TIMER_PIN_MAP( 6, PB3 , 1,  0)
+    TIMER_PIN_MAP( 0, PA9 , 1,  0) \
+    TIMER_PIN_MAP( 1, PA8 , 1,  1) \
+    TIMER_PIN_MAP( 2, PC9 , 2,  0) \
+    TIMER_PIN_MAP( 3, PC8 , 2,  1) \
+    TIMER_PIN_MAP( 4, PB3 , 1,  0)
 
 #define MOTOR1_PIN           PA9
 #define MOTOR2_PIN           PA8
@@ -106,19 +104,18 @@
 #define MOTOR4_PIN           PC8
 #define LED_STRIP_PIN        PB3
 
-#define ADC3_DMA_OPT        0
+#define ADC3_DMA_OPT         0
 
 #define INVERTER_PIN_UART1   PC0
 #define ESCSERIAL_PIN        PB9
 #define PINIO1_PIN           PB0
 
-#define USE_BARO
 #define BARO_I2C_INSTANCE (I2CDEV_1)
 #define MAG_I2C_INSTANCE (I2CDEV_1)
 
-#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
-#define DEFAULT_DSHOT_BURST DSHOT_DMAR_ON
-#define PINIO1_BOX 0
-#define PINIO1_CONFIG 129
+#define DEFAULT_BLACKBOX_DEVICE      BLACKBOX_DEVICE_FLASH
+#define DEFAULT_DSHOT_BURST          DSHOT_DMAR_OFF
+#define PINIO1_BOX                   0
+#define PINIO1_CONFIG                129
 #define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
 #define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC


### PR DESCRIPTION
DMA assignments were conflicting, preventing DShot from working when dshot_burst and dshot_bitbang were disabled, which should be default for this FC due to the F4 DMA errata.