### PR TITLE
[target] FF_RACEPITF7 add gyro & flash

### DIFF
--- a/configs/FF_RACEPITF7/config.h
+++ b/configs/FF_RACEPITF7/config.h
@@ -26,6 +26,14 @@
 #define BOARD_NAME        FF_RACEPITF7
 #define MANUFACTURER_ID   FFPV
 
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
 #define BEEPER_PIN           PC3
 #define MOTOR1_PIN           PB0
 #define MOTOR2_PIN           PB1


### PR DESCRIPTION
- documents report MPU6000
- assuming W25Q128FV same as FF_RACEPITF7_MINI
- fixes:
```
./src/main/sensors/acceleration_init.c:99:2: error: #error At least one USE_ACC device definition required
   99 | #error At least one USE_ACC device definition required
      |  ^~~~~
./src/main/sensors/acceleration_init.c: In function 'accDetect':
./src/main/sensors/acceleration_init.c:160:26: error: unused parameter 'dev' [-Werror=unused-parameter]
  160 | bool accDetect(accDev_t *dev, accelerationSensor_e accHardwareToUse)
      |                ~~~~~~~~~~^~~
%% (size optimised) ./src/main/cms/cms.c 
cc1: all warnings being treated as errors
./src/main/sensors/gyro_init.c:83:2: error: #error At least one USE_GYRO device definition required
   83 | #error At least one USE_GYRO device definition required
      |  ^~~~~
make[2]: *** [Makefile:454: obj/main/STM32F7X2_FF_RACEPITF7/sensors/acceleration_init.o] Error 1
make[2]: *** Waiting for unfinished jobs....
./src/main/sensors/gyro_init.c: In function 'gyroDetect':
./src/main/sensors/gyro_init.c:356:57: error: unused parameter 'dev' [-Werror=unused-parameter]
  356 | STATIC_UNIT_TESTED gyroHardware_e gyroDetect(gyroDev_t *dev)
      |                                              ~~~~~~~~~~~^~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:455: obj/main/STM32F7X2_FF_RACEPITF7/sensors/gyro_init.o] Error 1
%% (size optimised) ./src/main/cms/cms_menu_blackbox.c 
make[2]: Leaving directory '/source'
make[1]: *** [Makefile:574: hex] Error 2
make[1]: Leaving directory '/source'
make: *** [mk/config.mk:62: FF_RACEPITF7] Error 2
make failed with 2
```