### PR TITLE
[target] GEP_F405_VTX_V3 add MPU6000

### DIFF
--- a/configs/GEP_F405_VTX_V3/config.h
+++ b/configs/GEP_F405_VTX_V3/config.h
@@ -26,6 +26,11 @@
 #define BOARD_NAME        GEP_F405_VTX_V3
 #define MANUFACTURER_ID   GEPR
 
+#define USE_ACC
+#define USE_ACC_SPI_MPU6000
+#define USE_GYRO
+#define USE_GYRO_SPI_MPU6000
+
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB0
 #define MOTOR2_PIN           PB1


### PR DESCRIPTION
- partially resolves #548
- https://discord.com/channels/1201422947445907466/1251125521534685194/1278198739760054295
- fixes:
```
./src/main/sensors/acceleration_init.c:97:2: error: #error At least one USE_ACC device definition required
   97 | #error At least one USE_ACC device definition required
      |  ^~~~~
./src/main/sensors/acceleration_init.c: In function 'accDetect':
./src/main/sensors/acceleration_init.c:158:26: error: unused parameter 'dev' [-Werror=unused-parameter]
  158 | bool accDetect(accDev_t *dev, accelerationSensor_e accHardwareToUse)
      |                ~~~~~~~~~~^~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:439: obj/main/STM32F405_GEP_F405_VTX_V3/sensors/acceleration_init.o] Error 1
make[2]: *** Waiting for unfinished jobs....
%% (optimised) ./src/main/blackbox/blackbox_io.c 
%% (size optimised) ./src/main/cms/cms.c 
./src/main/sensors/gyro_init.c:81:2: error: #error At least one USE_GYRO device definition required
   81 | #error At least one USE_GYRO device definition required
      |  ^~~~~
./src/main/sensors/gyro_init.c: In function 'gyroDetect':
./src/main/sensors/gyro_init.c:354:57: error: unused parameter 'dev' [-Werror=unused-parameter]
  354 | STATIC_UNIT_TESTED gyroHardware_e gyroDetect(gyroDev_t *dev)
      |                                              ~~~~~~~~~~~^~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:439: obj/main/STM32F405_GEP_F405_VTX_V3/sensors/gyro_init.o] Error 1
make[2]: Leaving directory '/source'
make[1]: *** [Makefile:556: hex] Error 2
make[1]: Leaving directory '/source'
make: *** [mk/config.mk:62: GEP_F405_VTX_V3] Error 2
make failed with 2
```
