### PR TITLE
Fix ADC DMA SEQUREH7V2

### DIFF
--- a/configs/SEQUREH7V2/config.h
+++ b/configs/SEQUREH7V2/config.h
@@ -113,8 +113,8 @@
     TIMER_PIN_MAP( 8, PA8,  1,  0 ) \
     TIMER_PIN_MAP( 9, PB3,  1, -1 ) 
 
-#define ADC1_DMA_OPT        0
-#define ADC3_DMA_OPT        0
+#define ADC1_DMA_OPT        8
+#define ADC3_DMA_OPT        9
 
 #define TIMUP1_DMA_OPT      0
 #define TIMUP2_DMA_OPT      0


### PR DESCRIPTION
While the target works well normally, if you try to use burst dshot, betaflight always puts the TIMUP3 peripheral on the first DMA stream, and for some reason it doesn't move the ADC DMA stream away from the first, and betaflight reads bad data and all the voltage readings go crazy. The solution is just to assign streams 8 and 9 as most other targets do.

Another point is that, I don't know if this is a general bug or just this FC but burst dshot only works with motors 1-4 and not in bidirectional mode, timer based works with all 8 and bidirectional mode apparently, but it gives DSHOT_TELEM arming flag. For now the only working bidirectional mode is bitbang. I have tried various things, from assigning manually every DMA stream, to adding manual DMA assigments for the SPI busses and everything in between, I cannot get anything other than bitbang to work. Another peculiar thing is that, locally compiling, the first SPI bus never appears when typing `dma show` in CLI, but it does when cloud building, both done with the exact same configuration.