### PR TITLE
Add FLTE manufacturer

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -47,6 +47,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FLHI|Fly High|https://elektronchika.github.io/flyhigh/|
 |FLLF|Flying Lemon FPV|https://github.com/flyinglemonfpv|
 |FLON|FlightOne|https://flightone.com/|
+|FLTE|FLYTEX LTD|https://www.flytex.pro/|
 |FLWO|Flywoo|https://flywoo.net/|
 |FLYS|FlySpark|https://flyspark.in/|
 |FOXE|Foxeer|http://www.foxeer.com/|


### PR DESCRIPTION
- closes #606
- awaiting a target
- draft update for target inclusion effective immediate: https://deploy-preview-493.dev.web.betaflight.com/docs/development/manufacturer/config-target-guidance