### PR TITLE
Fix DMA assignments for AIKONF4V2

### DIFF
--- a/configs/AIKONF4V2/config.h
+++ b/configs/AIKONF4V2/config.h
@@ -102,16 +102,16 @@
 
 #define TIMER_PIN_MAPPING \
                                             TIMER_PIN_MAP(0, PB6, 1,  0) \
-                                            TIMER_PIN_MAP(1, PC6, 2,  0) \
-                                            TIMER_PIN_MAP(2, PC7, 2,  0) \
-                                            TIMER_PIN_MAP(3, PC8, 2,  0) \
+                                            TIMER_PIN_MAP(1, PC6, 2,  1) \
+                                            TIMER_PIN_MAP(2, PC7, 2,  1) \
+                                            TIMER_PIN_MAP(3, PC8, 2,  1) \
                                             TIMER_PIN_MAP(4, PC9, 2,  0) \
                                             TIMER_PIN_MAP(5, PB0, 2,  0) \
                                             TIMER_PIN_MAP(6, PB1, 2,  0) \
                                             TIMER_PIN_MAP(5, PB3, 1, -1)
 
-#define ADC1_DMA_OPT                        0
-#define ADC_INSTANCE                        ADC1
+#define ADC3_DMA_OPT                        1
+#define ADC_INSTANCE                        ADC3
 
 #define MAG_I2C_INSTANCE                    I2CDEV_1
 
@@ -123,5 +123,3 @@
 #define DEFAULT_VOLTAGE_METER_SCALE         110
 
 #define PINIO1_BOX                          40
-
-#define DEFAULT_FEATURES                    (FEATURE_OSD | FEATURE_LED_STRIP)


### PR DESCRIPTION
M1-3 were all assigned to the same DMA stream.
ADC1 conflicts with SPI1_RX and M1, must use ADC3.
Features should not be defined in the config. 