### PR TITLE
Fix PPM timer in iFlight Blitz F435

### DIFF
--- a/configs/IFLIGHT_BLITZ_F435/config.h
+++ b/configs/IFLIGHT_BLITZ_F435/config.h
@@ -131,7 +131,7 @@
 
 // TIMERS & DMA
 #define TIMER_PIN_MAPPING               TIMER_PIN_MAP(  0, PA8,  1,  0 ) \
-                                        TIMER_PIN_MAP(  1, PA3,  1, -1 ) \
+                                        TIMER_PIN_MAP(  1, PA3,  3, -1 ) \
                                         TIMER_PIN_MAP(  2, PB0,  2,  1 ) \
                                         TIMER_PIN_MAP(  3, PB1,  2,  2 ) \
                                         TIMER_PIN_MAP(  4, PC8,  2,  3 ) \


### PR DESCRIPTION
PPM timer conflicted with motors 7 & 8. Moved to TIM9.
