### PR TITLE
Remove custom gyro defines when align preset is used II

### DIFF
--- a/configs/LUXHDAIO-G4/config.h
+++ b/configs/LUXHDAIO-G4/config.h
@@ -102,5 +102,4 @@
 
 #define GYRO_1_SPI_INSTANCE          SPI1
 #define GYRO_1_ALIGN                 CW0_DEG_FLIP
-#define GYRO_1_ALIGN_YAW             2700
 #define DEFAULT_ALIGN_BOARD_YAW      -45


### PR DESCRIPTION
- First part in #673
- This was missed in https://github.com/betaflight/betaflight/pull/14187
- Executed `make all_configs` to test all targets.
- Remaining targets missing defines are
    - GEMEF722
    - KD722
    - VGOODRCF411_DJI
    - VGOODRCF722_DJI