### PR TITLE
Tbs lucid fc fixes

### DIFF
--- a/configs/TBS_LUCID_FC/config.h
+++ b/configs/TBS_LUCID_FC/config.h
@@ -33,7 +33,6 @@
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_SPI_ICM42688P
-#define USE_SPI_GYRO
 
 #define GYRO_1_EXTI_PIN                     PC4
 #define GYRO_1_CS_PIN                       PA4
@@ -132,7 +131,7 @@
 
 #define ADC_INSTANCE                        ADC1
 #define BARO_I2C_INSTANCE                   I2CDEV_1
-#define MAG_I2C_INSTANCE                            I2CDEV_1
+#define MAG_I2C_INSTANCE                    I2CDEV_1
 
 #define DEFAULT_BLACKBOX_DEVICE             BLACKBOX_DEVICE_FLASH
 

--- a/configs/TBS_LUCID_PRO_FC/config.h
+++ b/configs/TBS_LUCID_PRO_FC/config.h
@@ -137,7 +137,7 @@
 #define DEFAULT_VOLTAGE_METER_SOURCE        VOLTAGE_METER_ADC
 
 #define DEFAULT_ALIGN_BOARD_ROLL            180
-#define DEFAULT_ALIGN_BOARD_YAW             0
+#define DEFAULT_ALIGN_BOARD_YAW             180
 
 #define SERIALRX_PROVIDER                   SERIALRX_CRSF
 #define SERIALRX_UART                       SERIAL_PORT_UART5


### PR DESCRIPTION
fixes:
. cleanup on tbs lucid fc
. fix board orientation on tbs lucid pro fc

comment:
the tbs lucid pro fc is not used imo (why?), but the board orientation should still be fixed, if someone uses it.
If it is ever used, we should remove the MPU6000 entries from the tbs lucid fc.