### PR TITLE
Update AIRBOTSUPERF4 SPI DMA

### DIFF
--- a/configs/AIRBOTSUPERF4/config.h
+++ b/configs/AIRBOTSUPERF4/config.h
@@ -119,11 +119,10 @@
 
 
 #define ADC1_DMA_OPT                        0
-#define SPI3_TX_DMA_OPT                     5
 
 #define ADC_INSTANCE                        ADC1
 #define BARO_I2C_INSTANCE                   I2CDEV_1
-#define MAG_I2C_INSTANCE                            I2CDEV_1
+#define MAG_I2C_INSTANCE                    I2CDEV_1
 
 #define DEFAULT_BLACKBOX_DEVICE             BLACKBOX_DEVICE_FLASH
 


### PR DESCRIPTION
Defining DMA for only SPI_SDO results in SPI_SDO not being assigned DMA. Removing the unnecessary assignment allows both streams to be assigned properly.

Before change:
```
# dma show

Currently active DMA:
--------------------
DMA1 Channel 1: ADC 1
DMA1 Channel 2: LED_STRIP
DMA1 Channel 3: DSHOT_BITBANG 3
DMA1 Channel 4: DSHOT_BITBANG 2
DMA1 Channel 5: SPI_SDO 1
DMA1 Channel 6: SPI_SDI 1
DMA1 Channel 7: SPI_SDI 3
DMA2 Channel 1: FREE
DMA2 Channel 2: FREE
DMA2 Channel 3: FREE
DMA2 Channel 4: FREE
DMA2 Channel 5: FREE
DMA2 Channel 6: FREE
DMA2 Channel 7: FREE
```

After change:
```
# dma show

Currently active DMA:
--------------------
DMA1 Channel 1: ADC 1
DMA1 Channel 2: LED_STRIP
DMA1 Channel 3: DSHOT_BITBANG 3
DMA1 Channel 4: DSHOT_BITBANG 2
DMA1 Channel 5: SPI_SDO 1
DMA1 Channel 6: SPI_SDI 1
DMA1 Channel 7: SPI_SDO 3
DMA2 Channel 1: SPI_SDI 3
DMA2 Channel 2: FREE
DMA2 Channel 3: FREE
DMA2 Channel 4: FREE
DMA2 Channel 5: FREE
DMA2 Channel 6: FREE
DMA2 Channel 7: FREE
```