### PR TITLE
TBS_LUCID_H7: fix gyro2 orientation

### DIFF
--- a/configs/TBS_LUCID_H7/config.h
+++ b/configs/TBS_LUCID_H7/config.h
@@ -44,7 +44,7 @@
 #define GYRO_2_CS_PIN        PE11
 #define GYRO_2_EXTI_PIN      PE15
 #define GYRO_2_SPI_INSTANCE  SPI4
-#define GYRO_2_ALIGN         CW180_DEG_FLIP
+#define GYRO_2_ALIGN         CW0_DEG_FLIP
 
 #define USE_BARO
 #define USE_BARO_DPS310


### PR DESCRIPTION
the default orientation of the second gyro is currently off by 180deg relating to the silkscreen