### PR TITLE
DSHOT_BITBANG_OFF by default for SPEEDYBEEF 405 WING

### DIFF
--- a/configs/SPEEDYBEEF405WING/config.h
+++ b/configs/SPEEDYBEEF405WING/config.h
@@ -49,6 +49,8 @@
 #define USE_SERVOS
 #endif
 
+#define DEFAULT_DSHOT_BITBANG DSHOT_BITBANG_OFF
+
 #define BEEPER_PIN         PC15
 #define MOTOR1_PIN         PB7
 #define MOTOR2_PIN         PB6


### PR DESCRIPTION
Dshot didn't work until `set dshot_bitbang = OFF`

Support id ticket for reference: `7f93d6a2-5713-472b-85ed-b9bd5567dfbb`

This PR changes the default to OFF for SPEEDYBEEF 405 WING (regular and mini FC)