### PR TITLE
tbs lucid fc remove gyro

### DIFF
--- a/configs/TBS_LUCID_FC/config.h
+++ b/configs/TBS_LUCID_FC/config.h
@@ -27,11 +27,9 @@
 #define MANUFACTURER_ID                     TEBS
 
 #define USE_ACC
-#define USE_ACC_SPI_MPU6000
 #define USE_ACC_SPI_ICM42688P
 
 #define USE_GYRO
-#define USE_GYRO_SPI_MPU6000
 #define USE_GYRO_SPI_ICM42688P
 
 #define GYRO_1_EXTI_PIN                     PC4


### PR DESCRIPTION
. follow pull request from #686
. gyro mpu6000 removed from tbs_lucid_fc
. gyro entry according to the manual
. for pro version tbs_lucid_pro_fc should now be used