### PR TITLE
Fix gyro alignment on JHEG474

### DIFF
--- a/configs/JHEG474/config.h
+++ b/configs/JHEG474/config.h
@@ -93,4 +93,4 @@
 #define MAX7456_SPI_INSTANCE            SPI2
 #define FLASH_SPI_INSTANCE              SPI3
 #define GYRO_1_SPI_INSTANCE             SPI1
-#define GYRO_1_ALIGN                    CW180_DEG
+#define GYRO_1_ALIGN                    CW90_DEG


### PR DESCRIPTION
Gyro alignment was wrong on my FC. Can someone else verify it should be CW90?
