### PR TITLE
Fix typo in FLYTEX405V2

### DIFF
--- a/configs/FLYTEX405V2/config.h
+++ b/configs/FLYTEX405V2/config.h
@@ -43,8 +43,8 @@
 #define MOTOR4_PIN PC6
 #define SERVO1_PIN PB6
 #define SERVO2_PIN PB7
-#define SERVO2_PIN PB8
-#define SERVO3_PIN PB9
+#define SERVO3_PIN PB8
+#define SERVO4_PIN PB9
 #define RX_PPM_PIN PA3
 #define LED_STRIP_PIN PA8
 #define LED0_PIN PB0


### PR DESCRIPTION
Fix typo in SERVO2, SERVO3 naming, as initially it caused build conflict.

## Pull-Request requirements
- Adhere to https://betaflight.com/docs/development/manufacturer/requirements-for-submission-of-targets.
  AND https://betaflight.com/docs/development/manufacturer/config-target-guidance
- Pull-Request only from a custom branch, not `master`.
- Replace this text with details of your own.