### PR TITLE
ark_fpv: enable uart4 esc serial telem

### DIFF
--- a/configs/ARK_FPV/config.h
+++ b/configs/ARK_FPV/config.h
@@ -72,13 +72,10 @@
 #define UART3_RX_PIN         PD9
 #define MSP_UART             SERIAL_PORT_UART3
 
-// NOTE: enabling this doesn't work, fw hangs
-// Bidirectional DShot telemetry is used instead
 // ESC Telemetry (RX only)
-// #define USE_ESCSERIAL
-// #define UART4_RX_PIN         PH14
-// #define ESC_SENSOR_UART      SERIAL_PORT_UART4
-// #define ESCSERIAL_PIN        PH14
+#define UART4_TX_PIN         PH13
+#define UART4_RX_PIN         PH14
+#define ESC_SENSOR_UART      SERIAL_PORT_UART4
 
 // VTX
 #define UART5_TX_PIN         PC12


### PR DESCRIPTION
This is an attempt to enable serial ESC telem on the ARK FPV flight controller.

Requires https://github.com/betaflight/betaflight/pull/14341
