### PR TITLE
Add DPS310 baro to Matek F405-STD

### DIFF
--- a/configs/MATEKF405STD/config.h
+++ b/configs/MATEKF405STD/config.h
@@ -31,6 +31,7 @@
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM20602
 #define USE_BARO_BMP280
+#define USE_BARO_DPS310
 #define USE_MAX7456
 #define USE_SDCARD
 


### PR DESCRIPTION
Some units of Matek F405-STD have the DPS310 baro instead of BMP280, according to the manufacturer: https://www.mateksys.com/?portfolio=f405-std#tab-id-8

I also have this kind of unit, and was not able to get the barometer working with the default build options. Adding BARO_DPS310 to the custom defines for the build fixed the issue.

Adding it to the config here, so others won't run into the same issue.