### PR TITLE
Fix ICM45605 in STELLARH7DEV

### DIFF
--- a/configs/STELLARH7DEV/config.h
+++ b/configs/STELLARH7DEV/config.h
@@ -102,17 +102,17 @@
 #define ICM45605_SPI_INSTANCE           SPI1
 #define ICM45605_EXTI_PIN               PC4
 #define ICM45605_CS_PIN                 PC0
-#define ICM45605_ALIGN                  CW180_DEG_FLIP
+#define ICM45605_ALIGN                  CW180_DEG
 // GYRO 3: ICM-45686 on SPI3
 #define ICM45686_SPI_INSTANCE           SPI3
 #define ICM45686_EXTI_PIN               PA9
 #define ICM45686_CS_PIN                 PD5
-#define ICM45686_ALIGN                  CW180_DEG_FLIP
+#define ICM45686_ALIGN                  CW180_DEG
 // GYRO 4: ICM-42688P on SPI3
 #define ICM42688P_SPI_INSTANCE          SPI3
 #define ICM42688P_EXTI_PIN              PA8
 #define ICM42688P_CS_PIN                PE3
-#define ICM42688P_ALIGN                 CW180_DEG_FLIP
+#define ICM42688P_ALIGN                 CW180_DEG
 
 // IMU selection
 #define ICM40609D                       1

--- a/configs/STELLARH7DEV/config.h
+++ b/configs/STELLARH7DEV/config.h
@@ -98,11 +98,11 @@
 #define ICM40609D_EXTI_PIN              PA4
 #define ICM40609D_CS_PIN                PA2
 #define ICM40609D_ALIGN                 CW180_DEG_FLIP
-// GYRO 2: ICM-42605 on SPI1
-#define ICM42605_SPI_INSTANCE           SPI1
-#define ICM42605_EXTI_PIN               PC4
-#define ICM42605_CS_PIN                 PC0
-#define ICM42605_ALIGN                  CW180_DEG_FLIP
+// GYRO 2: ICM-45605 on SPI1
+#define ICM45605_SPI_INSTANCE           SPI1
+#define ICM45605_EXTI_PIN               PC4
+#define ICM45605_CS_PIN                 PC0
+#define ICM45605_ALIGN                  CW180_DEG_FLIP
 // GYRO 3: ICM-45686 on SPI3
 #define ICM45686_SPI_INSTANCE           SPI3
 #define ICM45686_EXTI_PIN               PA9
@@ -116,7 +116,7 @@
 
 // IMU selection
 #define ICM40609D                       1
-#define ICM42605                        2
+#define ICM45605                        2
 #define ICM45686                        3
 #define ICM42688P                       4
 
@@ -131,12 +131,12 @@
 #define GYRO_1_SPI_INSTANCE             ICM40609D_SPI_INSTANCE
 #define GYRO_1_ALIGN                    ICM40609D_ALIGN
 #define USE_ACCGYRO_ICM40609D
-#elif USE_IMU1 == ICM42605
-#define GYRO_1_EXTI_PIN                 ICM42605_EXTI_PIN
-#define GYRO_1_CS_PIN                   ICM42605_CS_PIN
-#define GYRO_1_SPI_INSTANCE             ICM42605_SPI_INSTANCE
-#define GYRO_1_ALIGN                    ICM42605_ALIGN
-#define USE_ACCGYRO_ICM42605
+#elif USE_IMU1 == ICM45605
+#define GYRO_1_EXTI_PIN                 ICM45605_EXTI_PIN
+#define GYRO_1_CS_PIN                   ICM45605_CS_PIN
+#define GYRO_1_SPI_INSTANCE             ICM45605_SPI_INSTANCE
+#define GYRO_1_ALIGN                    ICM45605_ALIGN
+#define USE_ACCGYRO_ICM45605
 #elif USE_IMU1 == ICM45686
 #define GYRO_1_EXTI_PIN                 ICM45686_EXTI_PIN
 #define GYRO_1_CS_PIN                   ICM45686_CS_PIN
@@ -160,12 +160,12 @@
 #define GYRO_2_SPI_INSTANCE             ICM40609D_SPI_INSTANCE
 #define GYRO_2_ALIGN                    ICM40609D_ALIGN
 #define USE_ACCGYRO_ICM40609D
-#elif USE_IMU2 == ICM42605
-#define GYRO_2_EXTI_PIN                 ICM42605_EXTI_PIN
-#define GYRO_2_CS_PIN                   ICM42605_CS_PIN
-#define GYRO_2_SPI_INSTANCE             ICM42605_SPI_INSTANCE
-#define GYRO_2_ALIGN                    ICM42605_ALIGN
-#define USE_ACCGYRO_ICM42605
+#elif USE_IMU2 == ICM45605
+#define GYRO_2_EXTI_PIN                 ICM45605_EXTI_PIN
+#define GYRO_2_CS_PIN                   ICM45605_CS_PIN
+#define GYRO_2_SPI_INSTANCE             ICM45605_SPI_INSTANCE
+#define GYRO_2_ALIGN                    ICM45605_ALIGN
+#define USE_ACCGYRO_ICM45605
 #elif USE_IMU2 == ICM45686
 #define GYRO_2_EXTI_PIN                 ICM45686_EXTI_PIN
 #define GYRO_2_CS_PIN                   ICM45686_CS_PIN


### PR DESCRIPTION
This pull request updates the configuration for the STELLARH7DEV board to replace references to the ICM-42605 IMU with the ICM-45605 IMU. The changes ensure compatibility with the new IMU model by updating pin definitions, SPI instance references, and alignment configurations.

### Updates to IMU Configuration:

* **Replaced ICM-42605 with ICM-45605 in GYRO 2 setup:**
  Updated pin definitions, SPI instance, and alignment for GYRO 2 to reflect the switch to the ICM-45605 IMU. (`configs/STELLARH7DEV/config.h`, [configs/STELLARH7DEV/config.hL101-R105](diffhunk://#diff-93b31575253e25f98ba306c2bcabdb480a50b3d3db069a7ccb06f4e4f8a3b612L101-R105))

* **Updated IMU selection constants:**
  Changed the constant `ICM42605` to `ICM45605` in the IMU selection list. (`configs/STELLARH7DEV/config.h`, [configs/STELLARH7DEV/config.hL119-R119](diffhunk://#diff-93b31575253e25f98ba306c2bcabdb480a50b3d3db069a7ccb06f4e4f8a3b612L119-R119))

* **Modified conditional configurations for IMU1 and IMU2:**
  Replaced conditional blocks for `ICM42605` with `ICM45605` for both IMU1 and IMU2, updating all associated pin, SPI instance, and alignment definitions. (`configs/STELLARH7DEV/config.h`, [[1]](diffhunk://#diff-93b31575253e25f98ba306c2bcabdb480a50b3d3db069a7ccb06f4e4f8a3b612L134-R139) [[2]](diffhunk://#diff-93b31575253e25f98ba306c2bcabdb480a50b3d3db069a7ccb06f4e4f8a3b612L163-R168)