### PR TITLE
add disable gyro clock

### DIFF
--- a/configs/STELLARH7DEV/config.h
+++ b/configs/STELLARH7DEV/config.h
@@ -183,6 +183,11 @@
 #define GYRO_2_CLKIN_PIN                PB4
 #endif
 
+// Disable GYRO_CLKIN for testing and comparing results
+#ifdef USE_DISABLE_GYRO_CLKIN
+#undef USE_GYRO_CLKIN
+#endif
+
 // Blackbox
 #define USE_FLASH
 #define USE_FLASH_W25M02G


### PR DESCRIPTION
add disable gyro clock for testing and comparing results ICM42688P

Usage
* add `-DUSE_DISABLE_GYRO_CLKIN` using `EXTRA_FLAGS` for local build
* add  `DISABLE_GYRO_CLKIN` using `custom define` for cloud build 