### PR TITLE
Fix timer map for FLYTEX405V2

### DIFF
--- a/configs/FLYTEX405V2/config.h
+++ b/configs/FLYTEX405V2/config.h
@@ -82,7 +82,7 @@
 #define PINIO4_PIN PB1
 
 #define TIMER_PIN_MAPPING \
-          TIMER_PIN_MAP( 0, PC9, 2,  1 ) \
+          TIMER_PIN_MAP( 0, PC9, 2,  0 ) \
           TIMER_PIN_MAP( 1, PC8, 2,  1 ) \
           TIMER_PIN_MAP( 2, PC7, 2,  1 ) \
           TIMER_PIN_MAP( 3, PC6, 2,  1 ) \


### PR DESCRIPTION
Fix timer map for PC9 in FLYTEX405V2
