### PR TITLE
name change for aixs aio

### DIFF
--- a/configs/AXISARGUSF745AIO/config.h
+++ b/configs/AXISARGUSF745AIO/config.h
@@ -23,7 +23,7 @@
 
 #define FC_TARGET_MCU     STM32F7X2
 
-#define BOARD_NAME        AXIS_ARGUS_F745_AIO
+#define BOARD_NAME        AXISFLYINGF7AIO
 #define MANUFACTURER_ID   AXFL
 
 #define USE_ACC

--- a/configs/AXISARGUSF745AIO/config.h
+++ b/configs/AXISARGUSF745AIO/config.h
@@ -23,7 +23,7 @@
 
 #define FC_TARGET_MCU     STM32F7X2
 
-#define BOARD_NAME        ARGUSF7AIO
+#define BOARD_NAME        AXIS_ARGUS_F745_AIO
 #define MANUFACTURER_ID   AXFL
 
 #define USE_ACC


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the board name to "AXISFLYINGF7AIO" for improved clarity in configuration displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->