### PR TITLE
FURYF4OSD - fix pin timer and dma definition

### DIFF
--- a/configs/FURYF4OSD/config.h
+++ b/configs/FURYF4OSD/config.h
@@ -85,7 +85,7 @@
     TIMER_PIN_MAP( 0, PC9 , 2,  0) \
     TIMER_PIN_MAP( 1, PA3 , 1,  1) \
     TIMER_PIN_MAP( 2, PB0 , 2,  0) \
-    TIMER_PIN_MAP( 3, PB1 , 2,  0) \
+    TIMER_PIN_MAP( 3, PB1 , 1,  0) \
     TIMER_PIN_MAP( 4, PA2 , 1,  0) \
     TIMER_PIN_MAP( 5, PA0 , 2,  0) \
     TIMER_PIN_MAP( 6, PB9 , 2, -1)


### PR DESCRIPTION
Pin timer and DMA definition was wrong, LED and Motor wasnt working. This fix made it work again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated timer assignment for a specific pin to improve timer functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->