### PR TITLE
Fix SAKURAH743 Gyro

### DIFF
--- a/configs/SAKURAH743/config.h
+++ b/configs/SAKURAH743/config.h
@@ -90,7 +90,7 @@
 #define LED1_PIN             PB4
 #define LED2_PIN             PB5
 
-//spi1 for mpu6000(deleting)
+//spi1 for IIM42652 and baro
 #define SPI1_SCK_PIN         PA5
 #define SPI1_SDI_PIN         PA6
 #define SPI1_SDO_PIN         PA7
@@ -125,10 +125,10 @@
 #define PINIO3_PIN           PD11
 
 //sensor CS and EXTI
-#define GYRO_1_EXTI_PIN      PC4
-#define GYRO_2_EXTI_PIN      PB2
-#define GYRO_1_CS_PIN        PA4
-#define GYRO_2_CS_PIN        PE11
+#define GYRO_1_EXTI_PIN      PB2
+//#define GYRO_2_EXTI_PIN      PC4
+#define GYRO_1_CS_PIN        PE11
+//#define GYRO_2_CS_PIN        PA4
 #define BARO_CS_PIN          PC5
 
 /* CS1 pads for SPI2 connection:
@@ -138,34 +138,26 @@
 
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PA2 , 2,  0) \
-    TIMER_PIN_MAP( 1, PA3 , 2,  0) \
-    TIMER_PIN_MAP( 2, PB0 , 2,  0) \
-    TIMER_PIN_MAP( 3, PB1 , 2,  0) \
-    TIMER_PIN_MAP( 4, PA0 , 2,  0) \
-    TIMER_PIN_MAP( 5, PA1 , 2,  0) \
-    TIMER_PIN_MAP( 6, PE5 , 1,  0) \
-    TIMER_PIN_MAP( 7, PE6 , 1,  0) \
+    TIMER_PIN_MAP( 1, PA3 , 2,  1) \
+    TIMER_PIN_MAP( 2, PB0 , 2,  2) \
+    TIMER_PIN_MAP( 3, PB1 , 2,  3) \
+    TIMER_PIN_MAP( 4, PA0 , 2,  4) \
+    TIMER_PIN_MAP( 5, PA1 , 2,  5) \
+    TIMER_PIN_MAP( 6, PE5 , 1,  6) \
+    TIMER_PIN_MAP( 7, PE6 , 1, -1) \
     TIMER_PIN_MAP( 8, PD12, 1, -1) \
     TIMER_PIN_MAP( 9, PD13, 1, -1) \
     TIMER_PIN_MAP(10, PD14, 1, -1) \
     TIMER_PIN_MAP(11, PD15, 1, -1) \
     TIMER_PIN_MAP(12, PB8 , 1, -1) \
-    TIMER_PIN_MAP(13, PA8 , 1,  0) 
-
-
+    TIMER_PIN_MAP(13, PA8 , 1,  7) 
 
 #define ADC1_DMA_OPT        8
 #define ADC3_DMA_OPT        9
-#define TIMUP1_DMA_OPT      0
-#define TIMUP2_DMA_OPT      0
-#define TIMUP3_DMA_OPT      2
-#define TIMUP4_DMA_OPT      1
-#define TIMUP5_DMA_OPT      0
-#define TIMUP8_DMA_OPT      0
-
+#define TIMUP3_DMA_OPT      10
+#define TIMUP5_DMA_OPT      11
 
 #define USB_DETECT PD4
-
 
 //mag config
 #define MAG_I2C_INSTANCE I2CDEV_1


### PR DESCRIPTION
ICM42688 is "gyro 2" on this FC, but GYRO_CS and GYRO_EXTI were not being recognized because gyro 1 wasn't defined. Corrected pin assignments and fixed DMA requests. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated hardware configuration to reflect new sensor assignments and pin mappings.
	- Disabled secondary gyro sensor support.
	- Adjusted timer and DMA settings for improved hardware compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->