### PR TITLE
Fix timer map on SOLOGOODF405

### DIFF
--- a/configs/RUSHF7AIO/config.h
+++ b/configs/RUSHF7AIO/config.h
@@ -91,19 +91,19 @@
 #define GYRO_1_CS_PIN                   PA4
 
 #define TIMER_PIN_MAPPING               TIMER_PIN_MAP( 0, PB7,  1,  0) \
-                                        TIMER_PIN_MAP( 0, PC8,  2,  0) \
-                                        TIMER_PIN_MAP( 0, PC9,  2,  0) \
-                                        TIMER_PIN_MAP( 0, PA8,  1,  0) \
-                                        TIMER_PIN_MAP( 0, PA9,  1,  0) \
-                                        TIMER_PIN_MAP( 0, PB0,  2,  0) \
-                                        TIMER_PIN_MAP( 0, PB1,  2,  0) \
-                                        TIMER_PIN_MAP( 0, PA10, 1,  0) \
-                                        TIMER_PIN_MAP( 0, PB4,  1,  0) \
-                                        TIMER_PIN_MAP( 0, PB3,  1,  0)
+                                        TIMER_PIN_MAP( 1, PC8,  2,  0) \
+                                        TIMER_PIN_MAP( 2, PC9,  2,  0) \
+                                        TIMER_PIN_MAP( 3, PA8,  1,  0) \
+                                        TIMER_PIN_MAP( 4, PA9,  1,  0) \
+                                        TIMER_PIN_MAP( 5, PB0,  2,  0) \
+                                        TIMER_PIN_MAP( 6, PB1,  2,  0) \
+                                        TIMER_PIN_MAP( 7, PA10, 1,  0) \
+                                        TIMER_PIN_MAP( 8, PB4,  1,  0) \
+                                        TIMER_PIN_MAP( 9, PB3,  1,  0)
 
 #define ADC_INSTANCE                    ADC3
 #define BARO_I2C_INSTANCE               I2CDEV_1
-#define MAG_I2C_INSTANCE                        I2CDEV_1
+#define MAG_I2C_INSTANCE                I2CDEV_1
 #define FLASH_SPI_INSTANCE              SPI3
 #define GYRO_1_SPI_INSTANCE             SPI1
 #define MAX7456_SPI_INSTANCE            SPI2

--- a/configs/SOLOGOODF405/config.h
+++ b/configs/SOLOGOODF405/config.h
@@ -85,14 +85,14 @@
 
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PC8,  2, 1 ) \
-    TIMER_PIN_MAP( 0, PC9,  2, 0 ) \
-    TIMER_PIN_MAP( 0, PA8,  1, 2 ) \
-    TIMER_PIN_MAP( 0, PA9,  1, 1 ) \
-    TIMER_PIN_MAP( 0, PB0,  2, 0 ) \
-    TIMER_PIN_MAP( 0, PB1,  2, 0 ) \
-    TIMER_PIN_MAP( 0, PA10, 1, 0 ) \
-    TIMER_PIN_MAP( 0, PB4,  1, 0 ) \
-    TIMER_PIN_MAP( 0, PB3,  1, 0 )
+    TIMER_PIN_MAP( 1, PC9,  2, 0 ) \
+    TIMER_PIN_MAP( 2, PA8,  1, 2 ) \
+    TIMER_PIN_MAP( 3, PA9,  1, 1 ) \
+    TIMER_PIN_MAP( 4, PB0,  2, 0 ) \
+    TIMER_PIN_MAP( 5, PB1,  2, 0 ) \
+    TIMER_PIN_MAP( 6, PA10, 1, 0 ) \
+    TIMER_PIN_MAP( 7, PB4,  1, 0 ) \
+    TIMER_PIN_MAP( 8, PB3,  1, 0 )
 
 #define ADC3_DMA_OPT 1
 


### PR DESCRIPTION
Fixes #810


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated hardware timer assignments to ensure correct mapping for pins on the SOLOGOODF405 and RUSHF7AIO configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->