### PR TITLE
SEQUREH7V2 - Add support for DPS368

### DIFF
--- a/configs/SEQUREH7V2/config.h
+++ b/configs/SEQUREH7V2/config.h
@@ -32,6 +32,7 @@
 
 #define USE_BARO
 #define USE_BARO_BMP280
+#define USE_BARO_DPS310
 
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the DPS310 barometric sensor on the SEQUREH7V2 board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->