### PR TITLE
SEQUREH7 - Add support for DPS368

### DIFF
--- a/configs/SEQUREH7/config.h
+++ b/configs/SEQUREH7/config.h
@@ -30,6 +30,7 @@
 #define USE_GYRO_SPI_MPU6000
 #define USE_BARO
 #define USE_BARO_BMP280
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional barometer sensor (DPS310) on the SEQUREH7 board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->