### PR TITLE
Add support for new custom Acci FC board - ACCIF435ELITE

### DIFF
--- a/configs/ACCIF435ELITE/config.h
+++ b/configs/ACCIF435ELITE/config.h
@@ -1,0 +1,134 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     AT32F435G
+
+#define BOARD_NAME        ACCIF435ELITE
+#define MANUFACTURER_ID   CUST
+
+#define USE_ACC
+#define USE_GYRO
+
+#define USE_GYRO_CLKIN
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
+
+#define USE_BARO
+#define USE_BARO_DPS310
+#define DEFAULT_BARO_I2C_ADDRESS 119
+
+#define USE_FLASH
+#define USE_FLASH_M25P16
+#define USE_FLASH_W25Q128FV
+#define USE_FLASH_W25N01G
+
+// I/O
+#define LED0_PIN             PC15
+#define LED1_PIN             PC14
+#define BEEPER_PIN           PC13
+#define BEEPER_INVERTED
+#define LED_STRIP_PIN        PB3
+
+// ACC/GYRO SPI 1
+#define USE_SPI_GYRO
+#define GYRO_1_EXTI_PIN      PC4
+#define GYRO_1_CS_PIN        PA4
+#define GYRO_1_SPI_INSTANCE  SPI1
+#define GYRO_1_ALIGN CW0_DEG
+
+#define SPI1_SCK_PIN         PA5
+#define SPI1_SDI_PIN         PA6
+#define SPI1_SDO_PIN         PA7
+
+// FLASH SPI 2
+#define SPI2_SCK_PIN         PB13
+#define SPI2_SDI_PIN         PB14
+#define SPI2_SDO_PIN         PB15
+
+#define FLASH_CS_PIN         PB12
+#define FLASH_SPI_INSTANCE   SPI2
+
+// ADC
+#define USE_ADC
+#define ADC_VBAT_PIN         PC1
+#define ADC_RSSI_PIN         PC2
+#define ADC_CURR_PIN         PC3
+#define ADC_INSTANCE         ADC1
+
+// UART PORTS
+#define UART1_TX_PIN         PB6
+#define UART1_RX_PIN         PB7
+
+#define UART2_TX_PIN         PA2
+#define UART2_RX_PIN         PA3
+
+#define UART3_TX_PIN         PB10
+#define UART3_RX_PIN         PB11
+
+#define UART4_TX_PIN         PA0
+#define UART4_RX_PIN         PA1
+
+#define UART5_TX_PIN         PC12
+#define UART5_RX_PIN         PD2
+
+#define UART6_TX_PIN         PC6
+#define UART6_RX_PIN         PC7
+
+#define GYRO_1_CLKIN_PIN     PC5
+
+// TIMERS
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PA9 , 1,  1) \
+    TIMER_PIN_MAP( 1, PA8 , 1,  1) \
+    TIMER_PIN_MAP( 2, PC9 , 1,  0) \
+    TIMER_PIN_MAP( 3, PC8 , 1,  0) \
+    TIMER_PIN_MAP( 4, PB3 , 1,  0) \
+    TIMER_PIN_MAP( 5, PC5 , 1,  -1)
+
+// MOTORS PINOUT
+#define MOTOR1_PIN           PA9
+#define MOTOR2_PIN           PA8
+#define MOTOR3_PIN           PC9
+#define MOTOR4_PIN           PC8
+
+#define ADC1_DMA_OPT         1
+
+// BARO I2C
+#define BARO_I2C_INSTANCE I2CDEV_1
+#define MAG_I2C_INSTANCE I2CDEV_1
+#define USE_I2C_PULLUP
+
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
+
+// USERS
+#define PINIO1_PIN           PB1
+#define PINIO1_BOX 40
+#define PINIO1_CONFIG 129
+
+// DEFAULTS
+#define DEFAULT_BLACKBOX_DEVICE         BLACKBOX_DEVICE_FLASH
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SCALE     113
+#define DEFAULT_DSHOT_BURST DSHOT_DMAR_ON


### PR DESCRIPTION
### Summary

This pull request adds support for a new custom Betaflight target: ACCIF435ELITE. This target is designed for a custom flight controller developed by ACCI FPV and is based on the AT32F435 series.

### Key Details
- Target name: ACCIF435ELITE
- MCU: AT32F435

#### Custom board features
- ICM42688P connected via SPI (Gyro CLKIN supported)
- 6 UARTS available
- Baro DPS368
- 128MB Flash memory
- No analog OSD support
- USB C

### Notes
This is a custom target and is not associated with any manufacturer.
Tested on physical hardware with full flight functionality and peripheral support verified.
