### PR TITLE
Add led strip pin (AIKONF4V3)

### DIFF
--- a/configs/AIKONF4V3/config.h
+++ b/configs/AIKONF4V3/config.h
@@ -42,7 +42,7 @@
 #define MOTOR2_PIN           PC7
 #define MOTOR3_PIN           PC8
 #define MOTOR4_PIN           PC9
-#define RX_PPM_PIN           PB6
+#define LED_STRIP_PIN        PB6
 #define SERVO1_PIN           PB0
 #define SERVO2_PIN           PB1
 #define UART1_TX_PIN         PA9
@@ -81,7 +81,7 @@
     TIMER_PIN_MAP( 1, PC7 , 2,  1) \
     TIMER_PIN_MAP( 2, PC8 , 2,  1) \
     TIMER_PIN_MAP( 3, PC9 , 2,  0) \
-    TIMER_PIN_MAP( 4, PB6 , 1, -1) \
+    TIMER_PIN_MAP( 4, PB6 , 1,  0) \
     TIMER_PIN_MAP( 5, PB0 , 2, -1) \
     TIMER_PIN_MAP( 6, PB1 , 2, -1)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AIKONF4V3: PB6 now controls addressable LED strips for onboard lighting.
- Changes
  - PB6 repurposed from PPM receiver input to LED strip control; PPM on PB6 is no longer supported.
- Chores
  - Updated timer mapping for PB6 to ensure reliable LED strip operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->