### PR TITLE
Fix manufacturer ID

### DIFF
--- a/configs/JHEG474/config.h
+++ b/configs/JHEG474/config.h
@@ -24,7 +24,7 @@
 #define FC_TARGET_MCU       STM32G47X
 
 #define BOARD_NAME          JHEG474
-#define MANUFACTURER_ID     JHEM
+#define MANUFACTURER_ID     JHEF
 
 #define USE_ACC
 #define USE_GYRO


### PR DESCRIPTION
- fixes #860


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated manufacturer identifier for the JHEG474 profile (JHEM → JHEF). Users may see the new manufacturer name in device info, settings, and logs. No functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->