### PR TITLE
Add optional MAG definitions for BETAFPVF405 and BETAFPVF405_ELRS targets

### DIFF
--- a/configs/BETAFPVF405/config.h
+++ b/configs/BETAFPVF405/config.h
@@ -39,6 +39,11 @@
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#ifndef USE_MAG
+#define USE_MAG
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#endif
 
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB0
@@ -60,6 +65,8 @@
 #define UART4_RX_PIN         PA1
 #define UART5_RX_PIN         PD2
 #define UART6_RX_PIN         PC7
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
 #define INVERTER_PIN_UART3   PC9
 #define INVERTER_PIN_UART6   PC8
 #define LED0_PIN             PB5

--- a/configs/BETAFPVF405_ELRS/config.h
+++ b/configs/BETAFPVF405_ELRS/config.h
@@ -39,6 +39,11 @@
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456
+#ifndef USE_MAG
+#define USE_MAG
+#define USE_MAG_QMC5883
+#define USE_MAG_IST8310
+#endif
 
 #define BEEPER_PIN           PB4
 #define MOTOR1_PIN           PB0
@@ -57,6 +62,8 @@
 #define UART4_RX_PIN         PA1
 #define UART5_RX_PIN         PD2
 #define UART6_RX_PIN         PC7
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
 #define INVERTER_PIN_UART3   PC9
 #define INVERTER_PIN_UART6   PC8
 #define LED0_PIN             PB5


### PR DESCRIPTION
Hi. Please check.

This configures the I2C interface on the board for use with an external magnetometer.

The target board has an I2C pad.

Thank you.

<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/fa9b525f-9bfb-4c37-b590-8f31f5a66d4c" />
