### PR TITLE
Add FlyMod back to manufacturer list

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -56,6 +56,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FLLF|Flying Lemon FPV|https://github.com/flyinglemonfpv|
 |FLON|FlightOne|https://flightone.com/|
 |FLTE|FLYTEX LTD|https://www.flytex.pro/|
+|FLMO|FlyMod|https://flymod.net/|
 |FLWO|Flywoo|https://flywoo.net/|
 |FLYS|FlySpark|https://flyspark.in/|
 |FOXE|Foxeer|http://www.foxeer.com/|

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -54,9 +54,9 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FLHB|Flash Hobby Technology Co.,Limited|https://flashhobby.com/|
 |FLHI|Fly High|https://elektronchika.github.io/flyhigh/|
 |FLLF|Flying Lemon FPV|https://github.com/flyinglemonfpv|
+|FLMO|FlyMod|https://flymod.net/|
 |FLON|FlightOne|https://flightone.com/|
 |FLTE|FLYTEX LTD|https://www.flytex.pro/|
-|FLMO|FlyMod|https://flymod.net/|
 |FLWO|Flywoo|https://flywoo.net/|
 |FLYS|FlySpark|https://flyspark.in/|
 |FOXE|Foxeer|http://www.foxeer.com/|


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Updated the manufacturers list to include FlyMod (ID: FLMO) with a link (https://flymod.net/). The new entry is inserted between Flying Lemon FPV (FLLF) and FlightOne (FLON). No existing entries were removed or changed; the public manufacturers table now lists the additional vendor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->