### PR TITLE
Add HGLRCF435_AIO board

### DIFF
--- a/configs/HGLRCF435_AIO/config.h
+++ b/configs/HGLRCF435_AIO/config.h
@@ -1,0 +1,112 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     AT32F435G
+
+#define BOARD_NAME        HGLRCF435_AIO
+#define MANUFACTURER_ID   HGLR
+
+#define USE_ACC
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM42688P
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_MAX7456
+
+#define BEEPER_PIN        PC15
+#define LED0_PIN          PA13
+#define LED1_PIN          PA14
+
+#define MOTOR1_PIN        PB6
+#define MOTOR2_PIN        PB7
+#define MOTOR3_PIN        PB8
+#define MOTOR4_PIN        PB9
+
+#define LED_STRIP_PIN     PA8
+
+#define UART1_TX_PIN      PA9
+#define UART1_RX_PIN      PA10
+#define UART2_TX_PIN      PA2
+#define UART2_RX_PIN      PA3
+#define UART3_TX_PIN      PB10
+#define UART3_RX_PIN      PB11
+#define UART4_TX_PIN      PH3
+#define UART4_RX_PIN      PH2
+
+#define I2C2_SCL_PIN      PA0
+#define I2C2_SDA_PIN      PA1
+
+#define SPI1_SCK_PIN      PA5
+#define SPI1_SDI_PIN      PA6
+#define SPI1_SDO_PIN      PA7
+#define SPI2_SCK_PIN      PB13
+#define SPI2_SDI_PIN      PB14
+#define SPI2_SDO_PIN      PB15
+#define SPI3_SCK_PIN      PB3
+#define SPI3_SDI_PIN      PB4
+#define SPI3_SDO_PIN      PB5
+
+#define GYRO_1_CS_PIN     PA4
+#define GYRO_1_EXTI_PIN   PC14
+#define GYRO_1_SPI_INSTANCE SPI1
+#define USE_GYRO_CLKIN
+#define GYRO_CLKIN_PIN    PB2
+
+#define MAX7456_SPI_CS_PIN PB12
+#define MAX7456_SPI_INSTANCE SPI2
+
+#define FLASH_CS_PIN      PA15
+#define FLASH_SPI_INSTANCE SPI3
+
+#define BARO_I2C_INSTANCE I2CDEV_2
+#define MAG_I2C_INSTANCE  I2CDEV_2
+
+#define ADC_INSTANCE      ADC1
+#define ADC1_DMA_OPT      11
+#define ADC_VBAT_PIN      PB0
+#define ADC_CURR_PIN      PB1
+
+#define DEFAULT_BLACKBOX_DEVICE      BLACKBOX_DEVICE_FLASH
+#define DEFAULT_DSHOT_BITBANG        DSHOT_BITBANG_ON
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define BEEPER_INVERTED
+#define SYSTEM_HSE_MHZ     8
+
+#define GYRO_1_ALIGN            CW180_DEG
+#define DEFAULT_ALIGN_BOARD_YAW -45
+
+#define INVERTER_PIN_UART2 PC13
+
+#define SERIALRX_UART      SERIAL_PORT_USART2
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP(0, MOTOR1_PIN, 4, 1)    \
+    TIMER_PIN_MAP(1, MOTOR2_PIN, 4, 2)    \
+    TIMER_PIN_MAP(2, MOTOR3_PIN, 4, 3)    \
+    TIMER_PIN_MAP(3, MOTOR4_PIN, 4, 4)    \
+    TIMER_PIN_MAP(4, LED_STRIP_PIN, 1, 1) \
+    TIMER_PIN_MAP(5, GYRO_CLKIN_PIN, 2, 4)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for the HGLRCF435 AIO flight controller.
  - Enables onboard accel/gyro and barometer, OSD, and Blackbox flash logging.
  - Provides 4 motor outputs, beeper, status LEDs, LED strip, multiple UARTs, I2C/SPI, and current/voltage sensing.
  - Includes default serial RX, telemetry/metering settings, gyro clock-in, and board/gyro alignment presets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->