### PR TITLE
Remove CC (JHEF7DUAL)

### DIFF
--- a/configs/JHEF7DUAL/config.h
+++ b/configs/JHEF7DUAL/config.h
@@ -74,7 +74,6 @@
 #define SPI1_SDO_PIN         PA7
 #define SPI2_SDO_PIN         PB15
 #define SPI3_SDO_PIN         PB5
-#define CAMERA_CONTROL_PIN   PB8
 #define ADC_VBAT_PIN         PC2
 #define ADC_RSSI_PIN         PC0
 #define ADC_CURR_PIN         PC1
@@ -95,9 +94,7 @@
     TIMER_PIN_MAP( 4, PB3 , 1,  0) \
     TIMER_PIN_MAP( 5, PC9 , 2,  0) \
     TIMER_PIN_MAP( 6, PC8 , 2,  0) \
-    TIMER_PIN_MAP( 7, PA8 , 1,  0) \
-    TIMER_PIN_MAP( 8, PB8 , 1,  0)
-
+    TIMER_PIN_MAP( 7, PA8 , 1,  0)
 
 #define ADC3_DMA_OPT        1
 


### PR DESCRIPTION
- confirmed by JHEMCU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated JHEF7DUAL hardware pin configuration: removed camera control on PB8.
  * Adjusted timer pin mappings by removing the PB8 assignment; other mappings remain unchanged.
  * Impact: Setups using PB8 for camera trigger or timing will no longer function until reconfigured to supported pins. No changes to other pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->