### PR TITLE
Remove duplicate TIMUP definitions (SPRACINGH7ZERO)

### DIFF
--- a/configs/SPRACINGH7ZERO/config.h
+++ b/configs/SPRACINGH7ZERO/config.h
@@ -105,7 +105,7 @@
 #define USE_I2C_DEVICE_1        // Connected to BMP388 only
 #define I2C1_SCL_PIN            PB8
 #define I2C1_SDA_PIN            PB9
-#define I2C_DEVICE I2CDEV_1
+#define I2C_DEVICE              I2CDEV_1
 
 #define I2C2_SCL_PIN            NONE
 #define I2C2_SDA_PIN            NONE
@@ -138,6 +138,7 @@
 #define USE_ACC_SPI_MPU6500
 #define USE_GYRO
 #define USE_GYRO_SPI_MPU6500
+#define USE_BARO
 #define USE_BARO_BMP388
 #define USE_MAG
 #define USE_MAG_HMC5883
@@ -218,17 +219,8 @@
     TIMER_PIN_MAP(17, PB0, 2, 0) \
     TIMER_PIN_MAP(18, PB1, 2, 0)
 
-#define TIMUP1_DMA_OPT 0
-#define TIMUP2_DMA_OPT 0
-#define TIMUP3_DMA_OPT 0
-#define TIMUP4_DMA_OPT 0
-#define TIMUP5_DMA_OPT 0
-#define TIMUP8_DMA_OPT 2
-
-#define MAG_I2C_INSTANCE I2CDEV_1
-
-#define USE_BARO
-#define BARO_I2C_INSTANCE I2CDEV_1
+#define MAG_I2C_INSTANCE     I2CDEV_1
+#define BARO_I2C_INSTANCE    I2CDEV_1
 
 #define GYRO_1_SPI_INSTANCE  SPI3
 #define GYRO_1_ALIGN         CW180_DEG


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Cleaned up hardware configuration for the SPRACING H7 ZERO target to remove unused low-level options.
  - Aligned sensor configuration for magnetometer and barometer; no functional changes expected.
  - Ensured barometer settings remain unchanged from prior behavior.
- Style
  - Improved formatting and whitespace in configuration files for readability.

No user-visible changes are expected; this update focuses on internal consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->