### PR TITLE
Fix BETAFPVH725 default config

### DIFF
--- a/configs/BETAFPVH725/config.h
+++ b/configs/BETAFPVH725/config.h
@@ -99,7 +99,7 @@
     TIMER_PIN_MAP( 2, MOTOR2_PIN,    1,  2 ) \
     TIMER_PIN_MAP( 3, MOTOR3_PIN,    2,  3 ) \
     TIMER_PIN_MAP( 4, MOTOR4_PIN,    2,  4 ) \
-    TIMER_PIN_MAP( 5,        PB7,    2, -1 )
+    TIMER_PIN_MAP( 5, GYRO_1_CLKIN_PIN, 2, -1 )
 
 #define ADC_INSTANCE                    ADC3
 #define ADC3_DMA_OPT                    10


### PR DESCRIPTION

Hi. Please check.

There are currently no products on the market using this target. 

This time we will modify the default config of the board.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for external gyro clock input to improve gyro stability on compatible setups.
  * Set a default board yaw alignment to 45° to simplify configuration for rotated board installations.

* **Chores**
  * Reassigned the first programmable I/O (PINIO1) to a different hardware pad — users may need to update wiring or related peripheral assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->