### PR TITLE
Add JHEF435PRO

### DIFF
--- a/configs/JHEF435PRO/config.h
+++ b/configs/JHEF435PRO/config.h
@@ -77,8 +77,8 @@
 #define TIMER_PIN_MAPPING   TIMER_PIN_MAP(0, PB6, 1,  0) \
                             TIMER_PIN_MAP(1, PA0, 1,  1) \
                             TIMER_PIN_MAP(2, PA1, 1,  2) \
-                            TIMER_PIN_MAP(3, PA2, 1,  3) \
-                            TIMER_PIN_MAP(4, PA3, 1,  4) \
+                            TIMER_PIN_MAP(3, PA3, 1,  3) \
+                            TIMER_PIN_MAP(4, PA2, 1,  4) \
                             TIMER_PIN_MAP(5, PA8, 1, -1)
 
 #define ADC_INSTANCE                    ADC1


### PR DESCRIPTION
**Checklist** 
- [x] passed schematics review
- [ ] passed hardware samples testing
- [x] follows guidelines
- [x] follows connector standards
- [ ] flight tested
- [x] comments/issues resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full support for JHEF435PRO (AT32F435G): ICM42688P IMU, DPS310 barometer, MAX7456 OSD, onboard W25Q128 flash with Blackbox default.
  * Preconfigured motor outputs, inverted beeper and LED0, UART/I2C/SPI and timer pin mappings (includes PA8), ADC/timer setup, 8 MHz HSE.
  * Defaults: ADC-based current/voltage sensing, DSHOT bitbang, −45° board yaw, PINIO1/BOX label "COB".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->