### PR TITLE
Add DPS310 support to SKYSTARSH7HD

### DIFF
--- a/configs/SKYSTARSH7HD/config.h
+++ b/configs/SKYSTARSH7HD/config.h
@@ -33,6 +33,7 @@
 #define USE_GYRO_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP280
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456


### PR DESCRIPTION
Support SPL06 baro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the DPS310 barometer sensor on the SKYSTARSH7HD target, enabling firmware builds that include this sensor alongside existing barometer options.
  * Improves hardware compatibility for users with DPS310-equipped boards.
  * Default behavior is unchanged; existing setups continue to work without modification unless the new sensor option is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->