### PR TITLE
Add target for Matek F411-WTE

### DIFF
--- a/configs/MATEKF411TE/config.h
+++ b/configs/MATEKF411TE/config.h
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32F411
+
+#define BOARD_NAME        MATEKF411TE
+#define MANUFACTURER_ID   MTKS
+
+#define USE_ACC
+#define USE_ACC_SPI_ICM42605
+#define USE_ACC_SPI_ICM42688P
+#define USE_ACC_SPI_BMI270
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM42605
+#define USE_GYRO_SPI_ICM42688P
+#define USE_GYRO_SPI_BMI270
+#define USE_MAX7456
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_MS5611
+#define USE_BARO_BMP085
+#define USE_BARO_DPS310
+#define USE_SOFTSERIAL
+#define USE_SOFTSERIAL1
+#define USE_SOFTSERIAL2
+
+
+#ifndef USE_WING
+#define USE_WING
+#endif
+
+#ifndef USE_SERVOS
+#define USE_SERVOS
+#endif
+
+#define DEFAULT_DSHOT_BITBANG DSHOT_BITBANG_OFF
+
+#define BEEPER_PIN           PB2
+#define MOTOR1_PIN           PB6
+#define MOTOR2_PIN           PB7
+#define SERVO1_PIN           PB0
+#define SERVO2_PIN           PB1
+#define SERVO3_PIN           PB4
+#define SERVO4_PIN           PB5
+#define LED_STRIP_PIN        PA8
+#define UART1_TX_PIN         PA9
+#define UART2_TX_PIN         PA2
+#define SOFTSERIAL1_TX_PIN   PA0
+#define SOFTSERIAL2_TX_PIN   PA15
+#define UART1_RX_PIN         PA10
+#define UART2_RX_PIN         PA3
+#define SOFTSERIAL1_RX_PIN   PA1
+#define SOFTSERIAL2_RX_PIN   PB3
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
+#define SPI2_SCK_PIN         PB13
+#define SPI2_SDI_PIN         PB14
+#define SPI2_SDO_PIN         PB15
+#define ADC_VBAT_PIN         PA4
+#define ADC_RSSI_PIN         PA6
+#define ADC_CURR_PIN         PA5
+#define PINIO1_PIN           PC15
+#define PINIO2_PIN           PB10
+#define LED0_PIN             PA14
+#define LED1_PIN             PA13
+#define MAX7456_SPI_CS_PIN   PB12
+#define GYRO_1_CS_PIN        PC13
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB6 , 1,  0) \
+    TIMER_PIN_MAP( 1, PB7 , 1,  0) \
+    TIMER_PIN_MAP( 2, PB0 , 2, 0) \
+    TIMER_PIN_MAP( 3, PB1 , 2, 0) \
+    TIMER_PIN_MAP( 4, PB4 , 2, 0) \
+    TIMER_PIN_MAP( 5, PB5 , 2, 0) \
+    TIMER_PIN_MAP( 6, PA8 , 1,  0)
+
+#define ADC1_DMA_OPT                   0
+
+#define SERIALRX_UART                  SERIAL_PORT_USART2
+
+#define DEFAULT_PID_PROCESS_DENOM      2
+#define MAG_I2C_INSTANCE               I2CDEV_1
+#define BARO_I2C_INSTANCE              I2CDEV_1
+#define DEFAULT_DSHOT_BURST            DSHOT_DMAR_AUTO
+#define DEFAULT_CURRENT_METER_SOURCE   CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE   VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE    250
+#define BEEPER_INVERTED
+#define SYSTEM_HSE_MHZ                 8
+#define MAX7456_SPI_INSTANCE           SPI2
+#define GYRO_1_SPI_INSTANCE            SPI2
+#define GYRO_1_ALIGN                   CW180_DEG_FLIP


### PR DESCRIPTION
## Pull-Request requirements

**Mandatory Review for All New Flight Controllers**

The flight controller is an existing one from Matek that has INAV support. I ported over the the INAV config to the Betaflight format as best I could, but need a thorough review, especially on timers for servos. Thank you. 

https://www.mateksys.com/?portfolio=f411-wte

**Hardware Compliance Requirements**

The flight controller is a port from INAV. 

**Housekeeping** 
- Pull-Request only from a custom branch, not `master`.
- Replace this text with details of your own.

**Checklist** (✓/✕, or y/n)
- [ ] passed Betaflight team's schematics review
- [ ] passed hardware samples testing
- [ ] follows guidelines
- [ ] follows connector standards
- [ ] flight tested
- [ ] comments/issues resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added full support for the MATEKF411TE flight controller.
  - Preconfigured IMU options (accelerometer/gyroscope), multiple barometers, and onboard OSD (MAX7456).
  - Enabled soft-serial alongside UART, I2C, and SPI interfaces; LEDs and beeper supported.
  - Ready-to-use motor and servo outputs with wing/servo features enabled by default.
  - Defaults set for current/voltage metering, PID processing rate, and system clock.
  - Comprehensive pin and timer mappings for a smoother out‑of‑the‑box setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->