### PR TITLE
Add ZEXM to Manufacturers list

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -144,3 +144,4 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |YYRC|JLDZ||
 |ZEEZ|Zeez RC|https://www.zeezrc.com/|
 |ZERO|Zerodrag|https://zerodrag.in/|
+|ZEXM|Shenzhen Zexin Future Technology Co., Ltd|http://zexfpv.com/|


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a new manufacturer ID entry: ZEXM (Shenzhen Zexin Future Technology Co., Ltd) with contact URL http://zexfpv.com/ to the official list.
  - The entry is appended to the end of the table; all existing entries remain unchanged.
  - Users can now identify and reference this manufacturer in supported workflows.
  - No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->