### PR TITLE
Added AGPT as manufacturer

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -12,6 +12,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |AEDR|AEDROX|https://www.aedrox.com/|
 |AERO|AeroCogito|https://www.aerocogito.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|
+|AGPT|Air Gapped Technologies|https://www.airgapped.dk/|
 |AIKO|AIKON Electronics|https://www.aikon-electronics.com/|
 |AIRB|Airbot|https://store.myairbot.com/|
 |ALWH|Alienwhoop|https://shop.alienwhoop.us/|


### PR DESCRIPTION
Documentation:

- Added a new manufacturer ID entry: AGPT (Air Gapped Technologies ApS) with URL https://airgapped.dk/ to the official list.
- Entry is added alphabetically, placing it as number 4 from the top.
- No other changes made.