### PR TITLE
Add the missing UART3

### DIFF
--- a/configs/GEPRCF722_BT_HD_V3/config.h
+++ b/configs/GEPRCF722_BT_HD_V3/config.h
@@ -49,10 +49,12 @@
 #define LED_STRIP_PIN        PA1
 #define UART1_TX_PIN         PA9
 #define UART2_TX_PIN         PA2
+#define UART3_TX_PIN         PB10
 #define UART4_TX_PIN         PC10
 #define UART5_TX_PIN         PC12
 #define UART1_RX_PIN         PA10
 #define UART2_RX_PIN         PA3
+#define UART3_RX_PIN         PB11
 #define UART4_RX_PIN         PC11
 #define UART5_RX_PIN         PD2
 #define I2C2_SCL_PIN         PB10


### PR DESCRIPTION
Upon inspection, it was found that the definition of UART3 was missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled UART3 on the GEPRCF722 BT HD V3 target by adding TX/RX pin mapping, providing an additional serial port for peripherals (e.g., receivers, telemetry, GPS).
  * Improves flexibility and peripheral compatibility without altering existing UART configurations or other board settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->