### PR TITLE
Add Gear Up to manufacturers list

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -65,6 +65,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |GEEL|Geelang|https://geelang.com/|
 |GEFP|GetFPV LLC|https://www.getfpv.com/|
 |GEPR|GEPRC|https://geprc.com/|
+|GEUP|Gear Up|https://takeyourgear.com/|
 |GFPV|GE-FPV|http://www.ge-fpv.com/|
 |GMRC|Great Mountain RC|https://github.com/shanggl|
 |HAMO|Happymodel|http://www.happymodel.cn/|


### PR DESCRIPTION
EUNIFY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated Manufacturers reference to include GEUP Gear Up in the Manufacturer IDs table. This addition improves clarity when identifying supported manufacturers and serves as a more complete lookup for users. The table now reflects the latest entries, making it easier to find and verify manufacturer information directly within the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->