### PR TITLE
Fix timer map for TMOTORH743

### DIFF
--- a/configs/TMOTORH743/config.h
+++ b/configs/TMOTORH743/config.h
@@ -113,17 +113,12 @@
                                         TIMER_PIN_MAP( 7, PC9, 2,  7 ) \
                                         TIMER_PIN_MAP( 8, PA8, 1, 14 )
 
-//                                        TIMER_PIN_MAP( 9, PB3, 1,  0 ) \
-//                                        TIMER_PIN_MAP(10, PB4, 1,  0 ) \
-//                                        TIMER_PIN_MAP(11, PB5, 1,  0 )
-
 
 #define ADC1_DMA_OPT                    8
 #define ADC3_DMA_OPT                    9
-// #define TIMUP1_DMA_OPT                  0
-// #define TIMUP2_DMA_OPT                  0
-// #define TIMUP3_DMA_OPT                  0
-// #define TIMUP8_DMA_OPT                  0
+#define TIMUP2_DMA_OPT                 10
+#define TIMUP3_DMA_OPT                 11
+#define TIMUP8_DMA_OPT                 12
 
 #define MAG_I2C_INSTANCE                I2CDEV_1
 #define BARO_I2C_INSTANCE               I2CDEV_2


### PR DESCRIPTION
- Issue in https://github.com/betaflight/betaflight/issues/14724 highlighted some configuration issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined timer pin mapping for TMOTORH743, reducing and reordering available pin entries to match supported hardware.
  * Introduced new DMA option values for several timer-up channels to enable additional DMA configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->