### PR TITLE
Update confifix: correct PINIO2 assignment, redefine as 12V BEC switch 

### DIFF
--- a/configs/GEPRC_TAKER_H743MINI/config.h
+++ b/configs/GEPRC_TAKER_H743MINI/config.h
@@ -116,8 +116,9 @@
 #define PINIO1_CONFIG                   129
 #define PINIO1_CONFIG 1
 #define PINIO2_CONFIG 129
-#define PINIO1_BOX 32
+#define PINIO1_BOX 40
 #define PINIO2_BOX 41
+#define BOX_USER1_NAME "CAM 1,2"
 #define BOX_USER2_NAME "12V BEC OFF"
 #define GYRO_1_SPI_INSTANCE             SPI2
 #define MAX7456_SPI_INSTANCE            SPI4


### PR DESCRIPTION
Updated the pin mapping: previously assigned PINIO2 IO pin was incorrect.
PINIO2 has been redefined as the 12V BEC power switch control.
<img width="798" height="578" alt="17611822027592" src="https://github.com/user-attachments/assets/26007af9-c551-4ce3-9e9c-a8612e42ff33" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "CAM 1,2" and "12V BEC OFF" user controls for the GEPRC TAKER H743 MINI.

* **Configuration**
  * Updated IO pin assignments and control/box mappings to align hardware controls with the new options and improve IO behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->