### PR TITLE
MATEKH743 - Change GYRO_2_ALIGN to CW90_DEG_FLIP

### DIFF
--- a/configs/MATEKH743/config.h
+++ b/configs/MATEKH743/config.h
@@ -115,29 +115,26 @@
 
 #define TIMER_PIN_MAPPING \
     TIMER_PIN_MAP( 0, PB0 , 2,  0) \
-    TIMER_PIN_MAP( 1, PB1 , 2,  0) \
-    TIMER_PIN_MAP( 2, PA0 , 2,  0) \
-    TIMER_PIN_MAP( 3, PA1 , 2,  0) \
-    TIMER_PIN_MAP( 4, PA2 , 2,  0) \
-    TIMER_PIN_MAP( 5, PA3 , 2,  0) \
-    TIMER_PIN_MAP( 6, PD12, 1,  0) \
-    TIMER_PIN_MAP( 7, PD13, 1,  0) \
+    TIMER_PIN_MAP( 1, PB1 , 2,  1) \
+    TIMER_PIN_MAP( 2, PA0 , 2,  2) \
+    TIMER_PIN_MAP( 3, PA1 , 2,  3) \
+    TIMER_PIN_MAP( 4, PA2 , 2,  4) \
+    TIMER_PIN_MAP( 5, PA3 , 2,  5) \
+    TIMER_PIN_MAP( 6, PD12, 1,  6) \
+    TIMER_PIN_MAP( 7, PD13, 1,  7) \
     TIMER_PIN_MAP( 8, PE5 , 1, -1) \
     TIMER_PIN_MAP( 9, PE6 , 1, -1) \
-    TIMER_PIN_MAP(10, PA8 , 1,  0) \
+    TIMER_PIN_MAP(10, PA8 , 1,  8) \
     TIMER_PIN_MAP(11, PA15, 1, -1) \
     TIMER_PIN_MAP(12, PC7 , 2, -1) 
 
 
 
-#define ADC1_DMA_OPT        8
-#define ADC3_DMA_OPT        9
-#define TIMUP1_DMA_OPT      0
-#define TIMUP2_DMA_OPT      0
-#define TIMUP3_DMA_OPT      2
-#define TIMUP4_DMA_OPT      1
-#define TIMUP5_DMA_OPT      0
-#define TIMUP8_DMA_OPT      0
+#define ADC1_DMA_OPT        9
+#define ADC3_DMA_OPT        10
+#define TIMUP3_DMA_OPT      11
+#define TIMUP4_DMA_OPT      12
+#define TIMUP5_DMA_OPT      13
 
 #define BARO_I2C_INSTANCE I2CDEV_2
 #define MAG_I2C_INSTANCE I2CDEV_1


### PR DESCRIPTION
- fixes https://github.com/betaflight/betaflight/issues/14730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected gyroscope alignment on the MATEKH743 board to improve orientation and gyro accuracy.
  * Updated timer pin mappings to restore proper timer output behavior for affected pins (improving PWM and timer-driven peripherals).
  * Adjusted ADC and timer DMA configuration to stabilize ADC transfers and timer update handling across the board.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->