### PR TITLE
AEROH7DIGITAL: Correct LED pin mappings and add color comments

### DIFF
--- a/configs/AEROH7DIGITAL/config.h
+++ b/configs/AEROH7DIGITAL/config.h
@@ -62,9 +62,9 @@
 #define I2C1_SDA_PIN         PB9
 #define I2C4_SDA_PIN         PB7
 
-#define LED0_PIN             PD8
-#define LED1_PIN             PB14
-#define LED2_PIN             PB15
+#define LED0_PIN             PD8  // Blue
+#define LED1_PIN             PB15 // Green
+#define LED2_PIN             PB14 // Amber
 
 #define SPI1_SCK_PIN         PA5
 #define SPI1_SDI_PIN         PA6


### PR DESCRIPTION
**Checklist** (✓/✕, or y/n)
- [x] passed Betaflight team's schematics review
- [x] passed hardware samples testing
- [x] follows guidelines
- [x] follows connector standards
- [x] flight tested
- [x] comments/issues resolved

Simple reordering of LED pin assignments to match official documentation: [Betaflight FC LED usage color assignments](https://www.betaflight.com/docs/development/FC-LEDs).

LED1 (Green) and LED2 (Amber) were swapped, now corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected LED hardware pin assignments on AEROH7DIGITAL devices to ensure proper LED functionality and correct visual indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->