### PR TITLE
Add configuration file for RP2350 based MADFLIGHT_FC3

### DIFF
--- a/configs/MADFLIGHT_FC3/config.h
+++ b/configs/MADFLIGHT_FC3/config.h
@@ -61,17 +61,16 @@
 //#define USE_GYRO_CLKIN //TODO - gives compile error with betaflight_2025.12.0-beta
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM42688P
-#define USE_GYRO_SPI_ICM42605
 #define USE_ACC
 #define USE_ACC_SPI_ICM42688P
-#define USE_ACC_SPI_ICM42605
+#define USE_ACCGYRO_ICM45686
 #define USE_SPI_DEVICE_1
 #define SPI1_SCK_PIN         PA30
 #define SPI1_SDI_PIN         PA28
 #define SPI1_SDO_PIN         PA31
 #define GYRO_1_EXTI_PIN      PA27
 #define GYRO_1_CS_PIN        PA29
-#define GYRO_1_CLKIN_PIN     PA26  // for ICM42688P, needs #define USE_GYRO_CLKIN
+#define GYRO_1_CLKIN_PIN     PA26  // for ICM42688P,ICP45686 needs #define USE_GYRO_CLKIN
 #define GYRO_1_SPI_INSTANCE  SPI1
 #define GYRO_1_ALIGN         CW180_DEG
 


### PR DESCRIPTION
## Pull-Request requirements

**Mandatory Review for All New Flight Controllers**

- All new flight controllers must undergo the Betaflight review process, regardless of whether they use an existing target.
> work in progress, design details mailed to hardware@bf

**Hardware Compliance Requirements**

- All hardware must adhere to the [Manufacturer Design Guidelines](https://betaflight.com/docs/development/manufacturer/manufacturer-design-guidelines).
> done

- Adhere to the [Config Target Guidance] https://betaflight.com/docs/development/manufacturer/config-target-guidance
> done

**Checklist** (✓/✕, or y/n)
- [wip] passed Betaflight team's schematics review
- [wip] passed hardware samples testing
- [yes] follows guidelines
- [no ] follows connector standards 
> all external connections available on 2.54 pin header for easy soldering
- [yes ] flight tested
- [wip] comments/issues resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MADFLIGHT_FC3 flight controller configuration: comprehensive hardware mapping and feature toggles for MCU/board/manufacturer IDs, IMU (SPI gyro/accelerometer) options, optional barometer and magnetometer (I2C), SD card logging support, RGB LED and battery voltage sensing, internal/external UART/I2C/motor/PIO pinouts, and debug/tracing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->