### PR TITLE
Jhemcu f405 wing target

### DIFF
--- a/configs/JHEF405WING/config.h
+++ b/configs/JHEF405WING/config.h
@@ -1,0 +1,124 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU      STM32F405
+
+#define BOARD_NAME         JHEF405WING
+#define MANUFACTURER_ID    JHEF
+
+#define USE_ACC
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+#define USE_SDCARD
+#define USE_SDCARD_SPI
+#define USE_MAX7456
+#define USE_BARO
+#define USE_BARO_DPS310
+
+#ifndef USE_WING
+#define USE_WING
+#endif
+
+#ifndef USE_SERVOS
+#define USE_SERVOS
+#endif
+
+#define DEFAULT_DSHOT_BITBANG DSHOT_BITBANG_OFF
+
+#define BEEPER_PIN         PC15
+#define MOTOR1_PIN         PB7
+#define MOTOR2_PIN         PB6
+#define SERVO1_PIN         PB0
+#define SERVO2_PIN         PB1
+#define SERVO3_PIN         PC8
+#define SERVO4_PIN         PC9
+#define SERVO5_PIN         PB14
+#define SERVO6_PIN         PA15
+#define SERVO7_PIN         PB10
+#define LED_STRIP_PIN      PA8
+#define UART1_TX_PIN       PA9
+#define UART2_TX_PIN       PA2
+#define UART3_TX_PIN       PC10
+#define UART4_TX_PIN       PA0
+#define UART5_TX_PIN       PC12
+#define UART6_TX_PIN       PC6
+#define UART1_RX_PIN       PA10
+#define UART2_RX_PIN       PA3
+#define UART3_RX_PIN       PC11
+#define UART4_RX_PIN       PA1
+#define UART5_RX_PIN       PD2
+#define UART6_RX_PIN       PC7
+#define I2C1_SCL_PIN       PB8
+#define I2C1_SDA_PIN       PB9
+#define LED0_PIN           PA14
+#define LED1_PIN           PA13
+#define SPI1_SCK_PIN       PA5
+#define SPI2_SCK_PIN       PB13
+#define SPI3_SCK_PIN       PB3
+#define SPI1_SDI_PIN       PA6
+#define SPI2_SDI_PIN       PC2
+#define SPI3_SDI_PIN       PB4
+#define SPI1_SDO_PIN       PA7
+#define SPI2_SDO_PIN       PC3
+#define SPI3_SDO_PIN       PB5
+#define ADC_VBAT_PIN       PC0
+#define ADC_RSSI_PIN       PC5
+#define ADC_CURR_PIN       PC1
+#define PINIO1_PIN         PC13
+#define SDCARD_SPI_CS_PIN  PC14
+#define MAX7456_SPI_CS_PIN PB12
+#define GYRO_1_CS_PIN      PA4
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB7 , 1,  0) \
+    TIMER_PIN_MAP( 1, PB6 , 1,  0) \
+    TIMER_PIN_MAP( 2, PB0 , 2, -1) \
+    TIMER_PIN_MAP( 3, PB1 , 2, -1) \
+    TIMER_PIN_MAP( 4, PC8 , 2, -1) \
+    TIMER_PIN_MAP( 5, PC9 , 2, -1) \
+    TIMER_PIN_MAP( 6, PB14, 2, -1) \
+    TIMER_PIN_MAP( 7, PA15, 1, -1) \
+    TIMER_PIN_MAP( 8, PB10, 1, -1) \
+    TIMER_PIN_MAP( 9, PA8 , 1,  0) 
+
+#define ADC1_DMA_OPT                   0
+
+#define SERIALRX_UART                  SERIAL_PORT_USART1
+
+#define DEFAULT_PID_PROCESS_DENOM      2
+#define MAG_I2C_INSTANCE               I2CDEV_1
+#define BARO_I2C_INSTANCE              I2CDEV_1
+#define DEFAULT_BLACKBOX_DEVICE        BLACKBOX_DEVICE_SDCARD
+#define DEFAULT_DSHOT_BURST            DSHOT_DMAR_AUTO
+#define DEFAULT_CURRENT_METER_SOURCE   CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE   VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE    195
+#define BEEPER_INVERTED
+#define SYSTEM_HSE_MHZ                 8
+#define MAX7456_SPI_INSTANCE           SPI2
+#define PINIO1_CONFIG                  1
+#define PINIO1_BOX                     0
+#define SDCARD_SPI_INSTANCE            SPI3
+#define GYRO_1_SPI_INSTANCE            SPI1
+#define GYRO_1_ALIGN                   CW270_DEG


### PR DESCRIPTION
adding target for jhemcus f405 wing target. with the speedybee wing fcs not currently in production  this will be useful with the upcoming release. its pin for pin with the speedybee wing fc.

I have hardware on hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JHEF405WING flight controller board support (STM32F405 MCU)
  * Includes ICM42688P gyro/accelerometer, DPS310 barometer, SD card, and OSD capabilities
  * Configured for wing and servo platforms with comprehensive UART, SPI, I2C, and ADC mappings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->