### PR TITLE
VTX power is inverted

### DIFF
--- a/configs/LUXH743NDAA/config.h
+++ b/configs/LUXH743NDAA/config.h
@@ -193,6 +193,6 @@
 #define PINIO1_CONFIG                       1
 #define PINIO1_BOX                          40
 #define BOX_USER1_NAME                      "CAM 1,2"
-#define PINIO2_CONFIG                       129
+#define PINIO2_CONFIG                       1
 #define PINIO2_BOX                          41
 #define BOX_USER2_NAME                      "VTX PWR"


### PR DESCRIPTION
BEC is switched using a FET to the EN pin, which means the default (ON) state should be low.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted hardware configuration parameters for system optimization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->