### PR TITLE
Add AXISFLYING_H743PRO

### DIFF
--- a/configs/AXISFLYINGH743PRO/config.h
+++ b/configs/AXISFLYINGH743PRO/config.h
@@ -23,7 +23,7 @@
 
 #define FC_TARGET_MCU      STM32H743
 
-#define BOARD_NAME         AXISFLYING_H743PRO
+#define BOARD_NAME         AXISFLYINGH743PRO
 #define MANUFACTURER_ID    AXFL
 
 #define USE_ACC
@@ -154,7 +154,7 @@
 #define GYRO_1_SPI_INSTANCE             SPI1
 #define GYRO_1_ALIGN                    CW0_DEG
 #define GYRO_2_SPI_INSTANCE             SPI4
-#define GYRO_2_ALIGN                    CW270_DEG
+#define GYRO_2_ALIGN                    CW90_DEG
 #define DEFAULT_GYRO_TO_USE             GYRO_CONFIG_USE_GYRO_BOTH
 #define MAX7456_SPI_INSTANCE            SPI2
 #define FLASH_SPI_INSTANCE              SPI3


### PR DESCRIPTION
Voltage divider is the default 100k/10k.
Buzzer pin doesn't have a timer, so only active buzzer.

**Checklist**
- [X] passed Betaflight team's schematics review
- [x] passed hardware samples testing
- [X] follows guidelines
- [X] follows connector standards
- [ ] flight tested
- [x] comments/issues resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the AXISFLYINGH743PRO flight controller board with complete hardware configuration, including motor and servo outputs, integrated sensors (accelerometer, gyroscope, barometer), OSD display support, and comprehensive peripheral connectivity for full flight control capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->