### PR TITLE
Add DPS310 baro to Flycolor targets

### DIFF
--- a/configs/FLYCOLORF4/config.h
+++ b/configs/FLYCOLORF4/config.h
@@ -31,6 +31,7 @@
 #define USE_GYRO_SPI_MPU6500
 #define USE_BARO
 #define USE_BARO_BMP388
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456

--- a/configs/FLYCOLORF435/config.h
+++ b/configs/FLYCOLORF435/config.h
@@ -32,6 +32,7 @@
 #define USE_GYRO_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP388
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_M25P16
 #define USE_MAX7456

--- a/configs/FLYCOLORF7MICRO/config.h
+++ b/configs/FLYCOLORF7MICRO/config.h
@@ -31,6 +31,7 @@
 #define USE_GYRO_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP388
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456

--- a/configs/FLYCOLORH743/config.h
+++ b/configs/FLYCOLORH743/config.h
@@ -32,6 +32,7 @@
 #define USE_ACC_SPI_ICM42688P
 #define USE_BARO
 #define USE_BARO_BMP388
+#define USE_BARO_DPS310
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV
 #define USE_MAX7456


### PR DESCRIPTION
Now using the SPL07-003 baro

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DPS310 barometer sensor support across multiple flight controller configurations, enabling improved altitude sensing capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->