### PR TITLE
GepRC_Taker_F405AIO -fix motor pins and timers

### DIFF
--- a/configs/GEPRC_TAKER_F405AIO/config.h
+++ b/configs/GEPRC_TAKER_F405AIO/config.h
@@ -40,8 +40,8 @@
 #define BEEPER_PIN           PD7
 #define MOTOR1_PIN           PE9
 #define MOTOR2_PIN           PE11
-#define MOTOR3_PIN           PE13
-#define MOTOR4_PIN           PE14
+#define MOTOR3_PIN           PC08
+#define MOTOR4_PIN           PC09
 #define RX_PPM_PIN           PA3
 #define LED_STRIP_PIN        PD14
 #define UART1_TX_PIN         PA9
@@ -84,8 +84,8 @@
 #define TIMER_PIN_MAPPING \
 TIMER_PIN_MAP( 0, PE9 , 1,  2) \
 TIMER_PIN_MAP( 1, PE11, 1,  1) \
-TIMER_PIN_MAP( 2, PE13, 1,  1) \
-TIMER_PIN_MAP( 3, PE14, 1,  0) \
+TIMER_PIN_MAP( 2, PC08, 1,  1) \
+TIMER_PIN_MAP( 3, PC09, 1,  0) \
 TIMER_PIN_MAP( 4, PA3 , 3, -1) \
 TIMER_PIN_MAP( 5, PD14, 1,  0) \
 TIMER_PIN_MAP( 6, PB1 , 2, -1) 


### PR DESCRIPTION
After flashing 2025.12.0-RC4 onto the GepRC_Taker_F405AIO I found the pins and timers for Motors 3 and 4 are not correct.

CLI changes required were:
resource MOTOR 3 C08
resource MOTOR 4 C09
timer C08 AF3
timer C09 AF3
dma pin C08 1
dma pin C09 0

This PR attempts to address this.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Motor 3 and Motor 4 output pin assignments on the flight controller board to their proper hardware connections
  * Updated associated timer pin mappings to maintain proper synchronization between motor output channels and timer resources
  * Resolves motor control functionality issues on this hardware variant

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->