### PR TITLE
GEPRC_TAKER_H743MINI - Fix PINIO1_CONFIG definition in config.h

### DIFF
--- a/configs/GEPRC_TAKER_H743MINI/config.h
+++ b/configs/GEPRC_TAKER_H743MINI/config.h
@@ -113,8 +113,7 @@
 #define DEFAULT_CURRENT_METER_SCALE     100
 #define BEEPER_INVERTED
 #define FLASH_SPI_INSTANCE              SPI3
-#define PINIO1_CONFIG                   129
-#define PINIO1_CONFIG 1
+#define PINIO1_CONFIG                   1
 #define PINIO2_CONFIG 129
 #define PINIO1_BOX 40
 #define PINIO2_BOX 41


### PR DESCRIPTION
Found during testing firmware builds

```
In file included from ./src/main/platform.h:30,
                 from ./src/main/drivers/bus_i2c_timing.c:23:
./src/config/configs/GEPRC_TAKER_H743MINI/config.h:117: error: "PINIO1_CONFIG" redefined [-Werror]
  117 | #define PINIO1_CONFIG 1
      | 
./src/config/configs/GEPRC_TAKER_H743MINI/config.h:116: note: this is the location of the previous definition
  116 | #define PINIO1_CONFIG                   129
      | 
In file included from ./src/main/platform.h:30,
                 from ./src/platform/STM32/debug.c:22:
./src/config/configs/GEPRC_TAKER_H743MINI/config.h:117: error: "PINIO1_CONFIG" redefined [-Werror]
  117 | #define PINIO1_CONFIG 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GPIO pin configuration for the GEPRC_TAKER_H743MINI flight controller board. Corrected conflicting configuration values that affected pin I/O behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->