### PR TITLE
GEPRCF722_BT_HD - fix TIMER_PIN_MAPPING for correct pin configuration

### DIFF
--- a/configs/GEPRCF722_BT_HD/config.h
+++ b/configs/GEPRCF722_BT_HD/config.h
@@ -92,8 +92,8 @@
     TIMER_PIN_MAP( 5, PC7 , 2,  1) \
     TIMER_PIN_MAP( 6, PB6 , 1,  0) \
     TIMER_PIN_MAP( 7, PB7 , 1,  0) \
-    TIMER_PIN_MAP( 8, PB1 , 1,  0) \
-    TIMER_PIN_MAP( 9, PB0 , 1,  0) \
+    TIMER_PIN_MAP( 8, PB1 , 2,  0) \
+    TIMER_PIN_MAP( 9, PB0 , 2,  0) \
     TIMER_PIN_MAP(10, PA1 , 1,  0)
 
 #define ADC3_DMA_OPT        0


### PR DESCRIPTION
- CAMERA_CONTROL does not need DMA
- MOTOR 7 and 8 were using N channel timer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated hardware timer pin mappings to improve peripheral routing.

* **Bug Fixes**
  * Switched default motor signal handling to bit‑banged mode for more reliable output.
  * Removed an obsolete pin assignment to prevent conflicts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->