### PR TITLE
Remove define USE_LED_STRIP from config.h

### DIFF
--- a/configs/MADFLIGHT_FC3/config.h
+++ b/configs/MADFLIGHT_FC3/config.h
@@ -54,7 +54,6 @@
 #define DEFAULT_VOLTAGE_METER_SCALE    110 // 100k/10k divider
 
 // RGB LED
-#define USE_LED_STRIP
 #define LED_STRIP_PIN        PA46
 
 // Gyro+acc


### PR DESCRIPTION
Remove `#define USE_LED_STRIP` -> gives error while compiling with cloud build:

```
***** Commencing Build *****

VERSION:   2026.6.0-alpha
COMMIT:    536d4d2c5a92bb3bc6d3684097d4ca6636c67d5f
CONTAINER: master
BOARD:     MADFLIGHT_FC3/RP2350B
STARTED:   2026-01-02 07:47:25Z

...

In file included from ./src/main/platform.h:30,
                 from ./src/main/common/streambuf.c:24:
./src/config/configs/MADFLIGHT_FC3/config.h:57: error: "USE_LED_STRIP" redefined [-Werror]
   57 | #define USE_LED_STRIP
      | 
<command-line>: note: this is the location of the previous definition
cc1: all warnings being treated as errors

...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed LED strip compilation macro from the flight controller configuration, disabling LED strip-related functionality during the build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->