### PR TITLE
Add PrincipIoT H7 Pi target

### DIFF
--- a/configs/PRINCIPIOTH7PI/config.h
+++ b/configs/PRINCIPIOTH7PI/config.h
@@ -144,7 +144,6 @@
 #define GYRO_2_CS_PIN        PE11
 #define GYRO_2_SPI_INSTANCE  SPI4
 #define GYRO_2_ALIGN         CW0_DEG
-//#define GYRO_2_ALIGN_PITCH 1800
 
 // Baro
 #define USE_BARO


### PR DESCRIPTION
Adding the PrincipIoT H7 Pi target. I've been in communication with the dev team on Discord and will be sending a sample to Haslinghuis soon. 

Two open questions I have (I'm still a bit cloudy on these):
* Are the ADC DMA options configured correctly?
* Are the Timer DMA options configured correctly? 

**Checklist** (✓/✕, or y/n)
- [✓] passed Betaflight team's schematics review
- [✓] passed hardware samples testing
- [✓] follows guidelines
- [✓] follows connector standards
- [Shortly] flight tested
- [✓] comments/issues resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the PRINCIPIOTH7PI flight controller: enables motors/servos, beeper, LED strip, SD card blackbox logging, multiple UARTs, I2C/SPI sensors (dual IMUs, barometer, magnetometer), ADC-based voltage/current sensing, VTX power control via PINIO, RX/GPS routing, and flexible timer/PWM mappings for peripherals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->