### PR TITLE
Add JHEF405PROV2 target

### DIFF
--- a/configs/JHEF405PROV2/config.h
+++ b/configs/JHEF405PROV2/config.h
@@ -80,7 +80,7 @@
 #define PINIO2_PIN           PC15
 
 #define TIMER_PIN_MAPPING \
-    TIMER_PIN_MAP( 0, PB8 , 2, -1) \
+    TIMER_PIN_MAP( 0, PB8 , 1, -1) \
     TIMER_PIN_MAP( 1, PC6 , 2,  0) \
     TIMER_PIN_MAP( 2, PC7 , 2,  1) \
     TIMER_PIN_MAP( 3, PC8 , 2,  1) \
@@ -102,7 +102,7 @@
 #define MAX7456_SPI_INSTANCE           SPI2
 #define FLASH_SPI_INSTANCE             SPI3
 #define GYRO_1_SPI_INSTANCE            SPI1
-//#define GYRO_1_ALIGN                   CW90_DEG
+#define GYRO_1_ALIGN                   CW90_DEG
 #define PINIO1_BOX                     40
 #define PINIO1_CONFIG                  129
 #define BOX_USER1_NAME                 "10V BEC"

--- a/configs/JHEF405PROV2/config.h
+++ b/configs/JHEF405PROV2/config.h
@@ -99,7 +99,7 @@
 #define DEFAULT_VOLTAGE_METER_SOURCE   VOLTAGE_METER_ADC
 #define BEEPER_INVERTED
 #define SYSTEM_HSE_MHZ                 8
-#define MAX7456_SPI_INSTANCE           SPI3
+#define MAX7456_SPI_INSTANCE           SPI2
 #define FLASH_SPI_INSTANCE             SPI3
 #define GYRO_1_SPI_INSTANCE            SPI1
 //#define GYRO_1_ALIGN                   CW90_DEG

--- a/configs/JHEF405PROV2/config.h
+++ b/configs/JHEF405PROV2/config.h
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32F405
+
+#define BOARD_NAME        JHEF405PROV2
+#define MANUFACTURER_ID   JHEF
+
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_M25P16
+#define USE_MAX7456
+#define USE_GYRO_CLKIN
+#define GYRO_1_CLKIN_PIN     PB8
+
+#define BEEPER_PIN           PC13
+#define MOTOR1_PIN           PC6
+#define MOTOR2_PIN           PC7
+#define MOTOR3_PIN           PC8
+#define MOTOR4_PIN           PC9
+#define SERVO1_PIN           PB0
+#define SERVO2_PIN           PB1
+#define LED_STRIP_PIN        PA8
+#define UART1_TX_PIN         PA9
+#define UART2_TX_PIN         PA2
+#define UART3_TX_PIN         PB10
+#define UART4_TX_PIN         PA0
+#define UART5_TX_PIN         PC12
+#define UART1_RX_PIN         PA10
+#define UART2_RX_PIN         PA3
+#define UART3_RX_PIN         PB11
+#define UART4_RX_PIN         PA1
+#define UART5_RX_PIN         PD2
+#define I2C1_SCL_PIN         PB6
+#define I2C1_SDA_PIN         PB7
+#define LED0_PIN             PA15
+#define SPI1_SCK_PIN         PA5
+#define SPI2_SCK_PIN         PB13
+#define SPI3_SCK_PIN         PC10
+#define SPI1_SDI_PIN         PA6
+#define SPI2_SDI_PIN         PB14
+#define SPI3_SDI_PIN         PC11
+#define SPI1_SDO_PIN         PA7
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SDO_PIN         PB5
+#define ESCSERIAL_PIN        PD2
+#define ADC_VBAT_PIN         PC3
+#define ADC_RSSI_PIN         PC0
+#define ADC_CURR_PIN         PC2
+#define FLASH_CS_PIN         PB4
+#define MAX7456_SPI_CS_PIN   PB12
+#define GYRO_1_EXTI_PIN      PC4
+#define GYRO_1_CS_PIN        PA4
+#define PINIO1_PIN           PC14
+#define PINIO2_PIN           PC15
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB8 , 2, -1) \
+    TIMER_PIN_MAP( 1, PC6 , 2,  0) \
+    TIMER_PIN_MAP( 2, PC7 , 2,  1) \
+    TIMER_PIN_MAP( 3, PC8 , 2,  1) \
+    TIMER_PIN_MAP( 4, PC9 , 2,  0) \
+    TIMER_PIN_MAP( 5, PB0 , 2, -1) \
+    TIMER_PIN_MAP( 6, PB1 , 2, -1) \
+    TIMER_PIN_MAP( 7, PA8 , 1,  0)
+
+#define ADC3_DMA_OPT                   1
+#define ADC_INSTANCE                   ADC3
+#define MAG_I2C_INSTANCE               I2CDEV_1
+#define BARO_I2C_INSTANCE              I2CDEV_1
+#define DEFAULT_BLACKBOX_DEVICE        BLACKBOX_DEVICE_FLASH
+#define DEFAULT_DSHOT_BITBANG          DSHOT_BITBANG_OFF
+#define DEFAULT_CURRENT_METER_SOURCE   CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE   VOLTAGE_METER_ADC
+#define BEEPER_INVERTED
+#define SYSTEM_HSE_MHZ                 8
+#define MAX7456_SPI_INSTANCE           SPI3
+#define FLASH_SPI_INSTANCE             SPI3
+#define GYRO_1_SPI_INSTANCE            SPI1
+//#define GYRO_1_ALIGN                   CW90_DEG
+#define PINIO1_BOX                     40
+#define PINIO1_CONFIG                  129
+#define BOX_USER1_NAME                 "10V BEC"
+#define PINIO2_BOX                     40
+#define PINIO2_CONFIG                  1
+#define BOX_USER2_NAME                 "COB"


### PR DESCRIPTION
**Checklist** (✓/✕, or y/n)
- [x] passed Betaflight team's schematics review
- [ ] passed hardware samples testing
- [x] follows guidelines
- [x] follows connector standards
- [ ] flight tested
- [ ] comments/issues resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the JHEF405PROV2 flight controller: onboard accel/gyro, barometer, external display and onboard flash.
  * Enabled gyro clock input and complete timer mapping for PWM/ESC outputs.
  * Exposed full I/O mappings for motors, servos, LED strip, beeper, UART/I2C/SPI, ADC inputs and PINIOs.
  * Set sensible defaults: flash blackbox, ADC-based current/voltage meters, DShot disabled, beeper inversion and two user box labels ("10V BEC", "COB").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->