### PR TITLE
Add novax_H743_V1 board configuration (NOVX)

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -97,6 +97,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |MTKS|Matek Systems|http://www.mateksys.com/|
 |MZGC|Manaz GCS|https://www.shop-mzgcs.de/|
 |NAMO|Namimno Silan Electronic Technology Co., Ltd|http://namimnorc.com/|
+|NOVX|novaX|https://github.com/novaX-ALUX|
 |NEBD|NewBeeDrone|https://newbeedrone.com/|
 |NERC|NeutronRC|https://www.facebook.com/Neutronrc-575638996448880|
 |NGUA|NG.UAVP|https://ng.uavp.ch/Shop|

--- a/configs/novax_H743_V1/config.h
+++ b/configs/novax_H743_V1/config.h
@@ -1,0 +1,163 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32H743
+
+#define BOARD_NAME        novax_H743_V1
+#define MANUFACTURER_ID   NOVX
+
+#define USE_ACC
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO
+#define USE_GYRO_SPI_ICM42688P
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_MAG
+#define USE_MAG_IST8310
+#define USE_MAX7456
+#define USE_SDCARD
+
+#define BEEPER_PIN           PA15
+#define MOTOR1_PIN           PB0
+#define MOTOR2_PIN           PB1
+#define MOTOR3_PIN           PA0
+#define MOTOR4_PIN           PA1
+#define MOTOR5_PIN           PA2
+#define MOTOR6_PIN           PA3
+#define MOTOR7_PIN           PD12
+#define MOTOR8_PIN           PD13
+#define MOTOR9_PIN           PD14
+#define MOTOR10_PIN          PD15
+#define RX_PPM_PIN           PC7
+#define LED_STRIP_PIN        PA8
+#define UART1_TX_PIN         PA9
+#define UART2_TX_PIN         PD5
+#define UART3_TX_PIN         PD8
+#define UART4_TX_PIN         PB9
+#define UART6_TX_PIN         PC6
+#define UART7_TX_PIN         PE8
+#define UART8_TX_PIN         PE1
+#define UART1_RX_PIN         PA10
+#define UART2_RX_PIN         PD6
+#define UART3_RX_PIN         PD9
+#define UART4_RX_PIN         PB8
+#define UART6_RX_PIN         PC7
+#define UART7_RX_PIN         PE7
+#define UART8_RX_PIN         PE0
+#define I2C1_SCL_PIN         PB6
+#define I2C2_SCL_PIN         PB10
+#define I2C1_SDA_PIN         PB7
+#define I2C2_SDA_PIN         PB11
+#define LED0_PIN             PE3
+#define LED1_PIN             PE4
+#define SPI1_SCK_PIN         PA5
+#define SPI2_SCK_PIN         PB13
+#define SPI3_SCK_PIN         PB3
+#define SPI4_SCK_PIN         PE12
+#define SPI1_SDI_PIN         PA6
+#define SPI2_SDI_PIN         PB14
+#define SPI3_SDI_PIN         PB4
+#define SPI4_SDI_PIN         PE13
+#define SPI1_SDO_PIN         PD7
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SDO_PIN         PB5
+#define SPI4_SDO_PIN         PE14
+#define ADC_VBAT_PIN         PC0
+#define ADC_RSSI_PIN         PC5
+#define ADC_CURR_PIN         PC1
+#define ADC_EXTERNAL1_PIN    PC4  // Airspeed
+#define ADC_EXTERNAL2_PIN    PA4  // VBAT2
+#define ADC_EXTERNAL3_PIN    PA7  // Current2
+#define SDIO_CK_PIN          PC12
+#define SDIO_CMD_PIN         PD2
+#define SDIO_D0_PIN          PC8
+#define SDIO_D1_PIN          PC9
+#define SDIO_D2_PIN          PC10
+#define SDIO_D3_PIN          PC11
+#define PINIO1_PIN           PD10
+#define PINIO2_PIN           PD11
+#define PINIO3_PIN           PE6
+#define PINIO4_PIN           PE5
+#define MAX7456_SPI_CS_PIN   PB12
+#define GYRO_1_EXTI_PIN      PB2
+#define GYRO_2_EXTI_PIN      PE15
+#define GYRO_1_CS_PIN        PC15
+#define GYRO_2_CS_PIN        PE11
+
+/* CS1/CS2 pads for SPI3 connection:
+ *
+ * CS1 PD4
+ * CS2 PE2
+ */
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB0 , 2,  0) \
+    TIMER_PIN_MAP( 1, PB1 , 2,  1) \
+    TIMER_PIN_MAP( 2, PA0 , 2,  2) \
+    TIMER_PIN_MAP( 3, PA1 , 2,  3) \
+    TIMER_PIN_MAP( 4, PA2 , 2,  4) \
+    TIMER_PIN_MAP( 5, PA3 , 2,  5) \
+    TIMER_PIN_MAP( 6, PD12, 1,  6) \
+    TIMER_PIN_MAP( 7, PD13, 1,  7) \
+    TIMER_PIN_MAP( 8, PD14, 1,  8) \
+    TIMER_PIN_MAP( 9, PD15, 1,  9) \
+    TIMER_PIN_MAP(10, PA8 , 1, 10) \
+    TIMER_PIN_MAP(11, PC7 , 2, -1)
+
+#define ADC1_DMA_OPT        11
+#define ADC3_DMA_OPT        12
+#define TIMUP3_DMA_OPT      13
+#define TIMUP4_DMA_OPT      14
+#define TIMUP5_DMA_OPT      15
+
+#define BARO_I2C_INSTANCE I2CDEV_2
+#define MAG_I2C_INSTANCE  I2CDEV_2
+
+#define DEFAULT_RX_FEATURE FEATURE_RX_SERIAL
+#define SERIALRX_PROVIDER  SERIALRX_CRSF
+#define SERIALRX_UART      SERIAL_PORT_USART3
+
+#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_SDCARD
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SCALE 250
+#define BEEPER_INVERTED
+#define BEEPER_PWM_HZ 2500
+
+#define SDCARD_DETECT_PIN NONE
+#define SDIO_DEVICE SDIODEV_1
+#define SDIO_USE_4BIT 1
+#define MAX7456_SPI_INSTANCE SPI2
+
+#define PINIO1_BOX 40
+#define PINIO2_BOX 41
+#define PINIO3_BOX 42
+#define PINIO4_BOX 43
+
+#define GYRO_1_SPI_INSTANCE SPI1
+#define GYRO_1_ALIGN        CW0_DEG
+#define GYRO_2_SPI_INSTANCE SPI4
+#define GYRO_2_ALIGN        CW0_DEG
+
+#define USE_MULTI_GYRO
+#define ENSURE_MPU_DATA_READY_IS_LOW


### PR DESCRIPTION
## Summary

- Register manufacturer **NOVX** (novaX) in `Manufacturers.md`
- Add Unified Target board configuration for **novax_H743_V1**

### Board Specifications

| Item | Detail |
|------|--------|
| MCU | STM32H743VIH6 (480MHz, 2MB Flash) |
| IMU | Dual ICM-42688-P (SPI1 + SPI4) |
| Barometer | DPS310 (I2C2) |
| Compass | IST8310 (I2C2) |
| OSD | MAX7456 (SPI2) |
| SD Card | SDIO 4-bit |
| Motor Outputs | 10 PWM |
| UARTs | 7 (USART1/2/3/6, UART4/7/8) |
| PINIO | 4 |
| Default RX | CRSF on UART3 |

### Files Changed

- `Manufacturers.md` — Add NOVX manufacturer entry
- `configs/novax_H743_V1/config.h` — Board configuration

### Build Verification

- Firmware compiles successfully with `make CONFIG=novax_H743_V1` (Betaflight 2026.6.0-alpha, 554,573 B)

### Test Plan

- [ ] Hardware validation pending (board in manufacturing)
- [ ] IMU orientation to be confirmed on real hardware
- [ ] All peripherals to be tested