### PR TITLE
Add MICOAIR743V2

### DIFF
--- a/configs/MICOAIR743V2/config.h
+++ b/configs/MICOAIR743V2/config.h
@@ -1,0 +1,131 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU   STM32H743
+
+#define BOARD_NAME      MICOAIR743V2
+#define MANUFACTURER_ID MICO
+
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACCGYRO_BMI270
+#define USE_BARO
+#define USE_BARO_DPS310
+#define USE_SDCARD
+#define USE_MAX7456
+
+#define BEEPER_PIN PD15
+#define MOTOR1_PIN PE14
+#define MOTOR2_PIN PE13
+#define MOTOR3_PIN PE11
+#define MOTOR4_PIN PE9
+#define MOTOR5_PIN PB1
+#define MOTOR6_PIN PB0
+#define MOTOR7_PIN PD12
+#define MOTOR8_PIN PD13
+#define LED_STRIP_PIN PD14
+#define UART1_TX_PIN PA9
+#define UART2_TX_PIN PA2
+#define UART3_TX_PIN PD8
+#define UART4_TX_PIN PA0
+#define UART5_TX_PIN PB6
+#define UART6_TX_PIN PC6
+#define UART7_TX_PIN PE8
+#define UART8_TX_PIN PE1
+#define UART1_RX_PIN PA10
+#define UART2_RX_PIN PA3
+#define UART3_RX_PIN PD9
+#define UART4_RX_PIN PA1
+#define UART5_RX_PIN PB5
+#define UART6_RX_PIN PC7
+#define UART7_RX_PIN PE7
+#define UART8_RX_PIN PE0
+#define I2C1_SCL_PIN PB8
+#define I2C2_SCL_PIN PB10
+#define I2C1_SDA_PIN PB9
+#define I2C2_SDA_PIN PB11
+#define LED0_PIN PE3
+#define LED1_PIN PE2
+#define LED2_PIN PE4
+#define SPI1_SCK_PIN PA5
+#define SPI3_SCK_PIN PB3
+#define SPI1_SDI_PIN PA6
+#define SPI3_SDI_PIN PB4
+#define SPI1_SDO_PIN PA7
+#define SPI3_SDO_PIN PD6
+#define ADC_VBAT_PIN PC0
+#define ADC_CURR_PIN PC1
+
+#define SDIO_CK_PIN PC12
+#define SDIO_CMD_PIN PD2
+#define SDIO_D0_PIN PC8
+#define SDIO_D1_PIN PC9
+#define SDIO_D2_PIN PC10
+#define SDIO_D3_PIN PC11
+#define PINIO1_PIN PE5
+#define PINIO2_PIN PE6
+#define MAX7456_SPI_CS_PIN PB12
+#define GYRO_1_EXTI_PIN PB7
+#define GYRO_1_CS_PIN PA15
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, MOTOR1_PIN, 1,  0 ) \
+    TIMER_PIN_MAP( 1, MOTOR2_PIN, 1,  1 ) \
+    TIMER_PIN_MAP( 2, MOTOR3_PIN, 1,  2 ) \
+    TIMER_PIN_MAP( 3, MOTOR4_PIN, 1,  3 ) \
+    TIMER_PIN_MAP( 4, MOTOR5_PIN, 2,  4 ) \
+    TIMER_PIN_MAP( 5, MOTOR6_PIN, 2,  5 ) \
+    TIMER_PIN_MAP( 6, MOTOR7_PIN, 1,  6 ) \
+    TIMER_PIN_MAP( 7, MOTOR8_PIN, 1,  7 ) \
+    TIMER_PIN_MAP( 8, LED_STRIP_PIN, 1, 12 ) \
+    TIMER_PIN_MAP( 9, BEEPER_PIN, 1, -1 )
+
+#define ADC1_DMA_OPT 8
+#define ADC3_DMA_OPT 9
+#define TIMUP1_DMA_OPT 10
+#define TIMUP3_DMA_OPT 11
+
+#ifdef USE_OSD_HD
+#define MSP_DISPLAYPORT_UART SERIAL_PORT_USART2
+#endif
+#ifdef USE_GPS
+#define GPS_UART             SERIAL_PORT_USART3
+#endif
+#define ESC_SENSOR_UART      SERIAL_PORT_USART7
+
+#define MAG_I2C_INSTANCE I2CDEV_1
+#define BARO_I2C_INSTANCE I2CDEV_2
+#define ADC_INSTANCE ADC1
+#define DEFAULT_BLACKBOX_DEVICE BLACKBOX_DEVICE_SDCARD
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SCALE 211
+#define DEFAULT_CURRENT_METER_SCALE 707
+#define BEEPER_INVERTED
+#define MAX7456_SPI_INSTANCE SPI1
+#define PINIO1_BOX 40
+#define PINIO2_BOX 41
+#define PINIO1_CONFIG 129
+#define PINIO2_CONFIG 129
+#define USE_SPI_GYRO
+#define GYRO_1_SPI_INSTANCE SPI3

--- a/configs/MICOAIR743V2/config.h
+++ b/configs/MICOAIR743V2/config.h
@@ -111,7 +111,9 @@
 #ifdef USE_GPS
 #define GPS_UART             SERIAL_PORT_USART3
 #endif
+#define MSP_UART             SERIAL_PORT_USART1
 #define ESC_SENSOR_UART      SERIAL_PORT_USART7
+#define SERIALRX_UART        SERIAL_PORT_USART6
 
 #define MAG_I2C_INSTANCE I2CDEV_1
 #define BARO_I2C_INSTANCE I2CDEV_2
@@ -129,3 +131,5 @@
 #define PINIO2_CONFIG 129
 #define USE_SPI_GYRO
 #define GYRO_1_SPI_INSTANCE SPI3
+#define SDIO_USE_4BIT        1
+#define SDIO_DEVICE          SDIODEV_1


### PR DESCRIPTION
This target does not comply with Betaflight Manufacturer Design Guidelines:
- no schematics available
- does not follow Betaflight Connector Standard
- using BMI270 and SPA006
- needs dshot_bitbang when using motor 7 & 8
- perhaps we remove motor 5 - 8 and add AIO suffix.

Reference: https://micoair.com/flightcontroller_micoair743v2_aio_45a/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the MICOAIR743V2 flight controller.
  * Enables accelerometer & gyro (BMI270), barometer (DPS310), SD card logging, and on-screen display (OSD).
  * Full board I/O: up to 8 motors, beeper, LED strip, multiple UARTs, I2C/SPI, ADC-based current/voltage sensing, and extra GPIOs.
  * Defaults and scaling set for blackbox, telemetry and meter readings; 4-bit SD card mode supported.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/config/pull/1059?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->