### PR TITLE
Add STM32N657DK bring-up config

### DIFF
--- a/configs/STM32N657DK/config.h
+++ b/configs/STM32N657DK/config.h
@@ -37,7 +37,7 @@
 #define FC_TARGET_MCU                   STM32N657
 
 #define BOARD_NAME                      STM32N657DK
-#define MANUFACTURER_ID                 STMC
+#define MANUFACTURER_ID                 STMI
 
 // STM32N6570-DK ships with a 48 MHz HSE clock source.
 #define SYSTEM_HSE_MHZ                  48

--- a/configs/STM32N657DK/config.h
+++ b/configs/STM32N657DK/config.h
@@ -1,0 +1,72 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// STM32N6570-DK development bring-up config.
+//
+// Goal: exercise the STM32N657 platform path with synthetic sensors and the
+// on-board LCD acting as a runtime debug console for boot/trace output. No
+// real flight hardware is wired — the IMU/baro/mag/GPS stack runs against
+// the existing virtual drivers under src/main/drivers/{accgyro,compass,
+// barometer}/*_virtual.c.
+//
+// The LCD path is currently a placeholder backend (see
+// src/platform/STM32/lcd_ltdc_n6.c) that mirrors writes into a debug RAM
+// grid; real LTDC + PSRAM + DSI + RK050HR18 bring-up will replace the
+// placeholder over follow-up iterations on the actual board.
+
+#define FC_TARGET_MCU                   STM32N657
+
+#define BOARD_NAME                      STM32N657DK
+#define MANUFACTURER_ID                 STMC
+
+// STM32N6570-DK ships with a 48 MHz HSE clock source.
+#define SYSTEM_HSE_MHZ                  48
+
+// Keep the runtime config in RAM for the bring-up — no need for persistent
+// storage during platform exploration, and it sidesteps the flash-partition
+// path which currently expects USE_FLASHFS to ride alongside
+// CONFIG_IN_MEMORY_MAPPED_FLASH (a pre-existing latent issue in flash.c that
+// only surfaces in USE_CONFIG mode where common_pre.h defaults are skipped).
+#define CONFIG_IN_RAM
+
+// --- Synthetic sensors ---------------------------------------------------
+// No real sensors are wired; rely on the virtual drivers so the flight code
+// has something coherent to talk to during the platform bring-up.
+#define USE_ACC
+#define USE_VIRTUAL_ACC
+#define USE_GYRO
+#define USE_VIRTUAL_GYRO
+#define USE_BARO
+#define USE_VIRTUAL_BARO
+#define USE_MAG
+#define USE_VIRTUAL_MAG
+
+// --- LCD console ---------------------------------------------------------
+// Route printf/trace output to the on-board LCD via the LTDC panel backend.
+// The CLI keeps its existing USB-VCP path; the LCD shows runtime/debug
+// output during normal operation.
+#define ENABLE_LCD_CONSOLE              1
+#define LCD_CONSOLE_PANEL_LTDC
+#define LCD_CONSOLE_COLS                80
+#define LCD_CONSOLE_ROWS                30
+#define ENABLE_LCD_PRINTF_REDIRECT      1

--- a/configs/STM32N657DK/config.mk
+++ b/configs/STM32N657DK/config.mk
@@ -1,0 +1,4 @@
+# STM32N6570-DK config — pulls in the LTDC panel backend for the LCD console.
+# Path is resolved against VPATH (which includes $(PLATFORM_DIR) i.e.
+# src/platform), so this expands to src/platform/STM32/lcd_ltdc_n6.c.
+TARGET_SRC += STM32/lcd_ltdc_n6.c


### PR DESCRIPTION
## Summary

Companion config for **betaflight/betaflight#15153** — development bring-up config for the STM32N6570-DK that uses virtual sensors and routes `printf`/trace to the on-board 5" LCD via the new `ENABLE_LCD_CONSOLE` path (subsystem in **betaflight/betaflight#15148**).

The matching LTDC backend in betaflight is currently a placeholder; real LTDC/PSRAM/DSI bring-up will follow once the structure validates end-to-end.

## Notes

- `CONFIG_IN_RAM` is set explicitly. The N657 target.h auto-defaults to `CONFIG_IN_MEMORY_MAPPED_FLASH`, but `flash.c`'s partition path silently relies on `USE_FLASHFS` to ride alongside it — and `USE_FLASHFS` only comes from the `!USE_CONFIG` defaults in `common_pre.h`, so a `CONFIG=` build with the default flash mode trips an undeclared-variable error in `flashConfigurePartitions()`. `CONFIG_IN_RAM` sidesteps that and is appropriate for a bring-up dev board anyway.
- All DK-specific values (HSE, virtual-sensor enables, LCD dimensions) live here in `config.h` per the placement rule (target.h stays MCU-only).

## Test plan

- [x] `BETAFLIGHT_CONFIG=$HOME/src/config make CONFIG=STM32N657DK` builds clean (text 494404 / data 7576 / bss 88544)
- [ ] Real-hardware exercise: depends on the LTDC backend in betaflight#15153 being upgraded from placeholder to real silicon-driving code

## Dependencies

This PR depends on **betaflight/betaflight#15148** (LCD console subsystem) and **betaflight/betaflight#15153** (placeholder LTDC backend) — should land in tandem with #15153.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the STM32N657DK development board.
  * Enabled an on‑board LCD console for runtime debug and redirected printf/trace output to the display.
  * Added virtual/synthetic sensor inputs (accelerometer, gyro, barometer, magnetometer) for development and testing.
  * Switched runtime to in‑RAM mode and configured the platform clock to 48 MHz.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->