### PR TITLE
MADFLIGHT_FC3: enable USE_GYRO_CLKIN

### DIFF
--- a/configs/MADFLIGHT_FC3/config.h
+++ b/configs/MADFLIGHT_FC3/config.h
@@ -57,7 +57,7 @@
 #define LED_STRIP_PIN        PA46
 
 // Gyro+acc
-//#define USE_GYRO_CLKIN //TODO - gives compile error with betaflight_2025.12.0-beta
+#define USE_GYRO_CLKIN
 #define USE_GYRO
 #define USE_GYRO_SPI_ICM42688P
 #define USE_ACC


### PR DESCRIPTION
## Summary

Drops the TODO workaround in `MADFLIGHT_FC3/config.h` and enables `USE_GYRO_CLKIN` for the ICM-42688P / ICP-45686 sensors that need an external clock on `PA26`.

## Background

Previously commented out with `//TODO - gives compile error with betaflight_2025.12.0-beta`. The compile error came from `accgyro_spi_icm426xx.c` calling STM32-only timer/PWM APIs from `src/main`. The firmware-side fix introduces a platform abstraction (`drivers/gyro_clkin.h`) so the same caller works on both STM32 and PICO/RP2350.

Depends on betaflight/betaflight#15162.
