### PR TITLE
SITL_X_PLANE / SITL_REAL_FLIGHT: default to MSP RX

### DIFF
--- a/configs/SITL_REAL_FLIGHT/config.h
+++ b/configs/SITL_REAL_FLIGHT/config.h
@@ -32,3 +32,7 @@
 //   - GPS position used directly (no origin mirror)
 //   - barometric pressure read from fdm_packet
 #define ENABLE_GAZEBO_BRIDGE    0
+
+// RealFlight bridge does not push UDP RC packets; default to MSP RX over the
+// TCP-emulated UART so Configurator / test harnesses can drive RC channels.
+#define DEFAULT_RX_FEATURE      FEATURE_RX_MSP

--- a/configs/SITL_X_PLANE/config.h
+++ b/configs/SITL_X_PLANE/config.h
@@ -33,3 +33,7 @@
 //   - GPS position used directly (no origin mirror)
 //   - barometric pressure read from fdm_packet
 #define ENABLE_GAZEBO_BRIDGE    0
+
+// X-Plane bridge does not push UDP RC packets; default to MSP RX over the
+// TCP-emulated UART so Configurator / test harnesses can drive RC channels.
+#define DEFAULT_RX_FEATURE      FEATURE_RX_MSP


### PR DESCRIPTION
## Summary

Pin `DEFAULT_RX_FEATURE FEATURE_RX_MSP` on the `SITL_X_PLANE` and `SITL_REAL_FLIGHT` configs so they boot with MSP-over-TCP-UART as the default RC source.

## Why

The companion firmware fix (betaflight/betaflight#15164) replaces the unconditional `RX_PROVIDER_UDP` hardcode with a real `FEATURE_RX_UDP` and makes it the SITL default — perfect for the bare SITL target and `SITL_GAZEBO` (Gazebo Harmonic pushes RC over UDP port 9004), but a problem for the legacy bridges:

- **X-Plane bridge** (`BF-SITL-X-Plane-Bridge`): does not transmit UDP RC packets. RC arrives over the TCP-emulated UART via MSP.
- **RealFlight bridge**: same — no UDP RC channel.

Without this override, those configs would boot with `FEATURE_RX_UDP` enabled but never receive any RC frames, leaving the FC stuck on failsafe.

## Behaviour

`DEFAULT_RX_FEATURE` only affects fresh / defaulted configs (the `featureEnableImmediate(DEFAULT_RX_FEATURE)` call in `config.c` only fires when no RX feature is configured). Existing user configs are unaffected.

`SITL_GAZEBO` is unchanged — it correctly inherits the `FEATURE_RX_UDP` default from the SITL target.

## Test plan

- [ ] `make CONFIG=SITL_X_PLANE` builds clean.
- [ ] `make CONFIG=SITL_REAL_FLIGHT` builds clean.
- [ ] Reset to defaults; `feature` shows `RX_MSP` enabled, `RX_UDP` disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default receiver configurations for RealFlight and X-Plane SITL simulation platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->