### PR TITLE
Add support for LSM6DSK320X accelerometer/gyro

### DIFF
--- a/configs/HWH7/config.h
+++ b/configs/HWH7/config.h
@@ -39,6 +39,7 @@
 #define USE_GYRO_SPI_ICM42688P
 
 #define USE_ACCGYRO_LSM6DSV16X
+#define USE_ACCGYRO_LSM6DSK320X
 
 //barometer
 #define USE_BARO


### PR DESCRIPTION
Add LSM6DSK320X gyroscope support for existing targets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional accelerometer and gyroscope sensor option, expanding device hardware compatibility and enabling new configuration variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->