### PR TITLE
STM32N657DK_DSK320 + OPENN657V1: N6 bring-up configs

### DIFF
--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -1,0 +1,120 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// Open-hardware STM32N657 flight controller, v1.0 layout. Ported from
+// the upstream fork's monolithic target.h into the per-config layout
+// expected by current Betaflight master.
+//
+// Real sensors only — the SPI/I2C bring-up for N6 is being completed
+// in a parallel session, so this config commits to the actual ICM-42688P
+// IMU on SPI1. The BMP280 baro is wired on I2C but the bus/pin
+// assignment was never finalised in the source we received, so it stays
+// behind a TODO until that's confirmed.
+
+#define FC_TARGET_MCU                   STM32N657
+
+#define BOARD_NAME                      OPENN657V1
+#define MANUFACTURER_ID                 CUST
+
+// 48 MHz HSE crystal — matches the fork's target.mk and the N6570-DK
+// reference clock tree the platform expects.
+#define SYSTEM_HSE_MHZ                  48
+
+// N6 has no internal user flash; the runtime config has to live in RAM
+// (or external flash, once the XSPI self-flasher path is exercised on
+// this board). Stay in RAM for bring-up.
+#define CONFIG_IN_RAM
+
+// --- USB VCP -------------------------------------------------------------
+// Opted in per-board because the boot ROM hands USB power-rail state off
+// non-deterministically and each board does its own MspInit sequencing.
+#define USE_VCP
+
+// --- LEDs ----------------------------------------------------------------
+#define LED0_PIN                        PD15
+#define LED1_PIN                        PG10
+
+// --- Serial --------------------------------------------------------------
+// UART3: bidirectional debug / MSP
+#define UART3_TX_PIN                    PE8
+#define UART3_RX_PIN                    PE0
+
+// UART4: SBUS RX (RX-only on the fork target)
+#define UART4_RX_PIN                    PD0
+#define SERIALRX_UART                   SERIAL_PORT_UART4
+#define USE_SERIALRX
+#define USE_SERIALRX_SBUS
+#define SERIALRX_PROVIDER               SERIALRX_SBUS
+
+// UART5/6: free RX-capable pads exposed on the board
+#define UART5_RX_PIN                    PH2
+#define UART6_RX_PIN                    PC9
+
+// --- IMU: ICM-42688P on SPI1 --------------------------------------------
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
+
+#define SPI1_SCK_PIN                    PB9
+#define SPI1_SDI_PIN                    PB8
+#define SPI1_SDO_PIN                    PA7
+
+#define ICM42688P_SPI_INSTANCE          SPI1
+#define ICM42688P_CS_PIN                PE2
+#define ICM42688P_EXTI_PIN              PA3
+#define ICM42688P_ALIGN                 CW180_DEG
+
+#define GYRO_1_SPI_INSTANCE             ICM42688P_SPI_INSTANCE
+#define GYRO_1_CS_PIN                   ICM42688P_CS_PIN
+#define GYRO_1_EXTI_PIN                 ICM42688P_EXTI_PIN
+#define GYRO_1_ALIGN                    ICM42688P_ALIGN
+
+// --- Baro ----------------------------------------------------------------
+// TODO BMP280 I2C wiring — bus + SCL/SDA pins not finalised in the fork
+// target.h we received. Confirm against the v1.0 schematic and uncomment
+// (matching I2Cx_SCL_PIN/I2Cx_SDA_PIN against the chosen instance).
+//
+// #define USE_BARO
+// #define USE_BARO_BMP280
+// #define BARO_I2C_INSTANCE             I2CDEV_?
+// #define I2C?_SCL_PIN                  P??
+// #define I2C?_SDA_PIN                  P??
+
+// --- Motors --------------------------------------------------------------
+// TODO MOTOR3/MOTOR4 wiring — PD2 and PC12 are inherited from the fork's
+// target.h but neither pin has a TIM1_CH3/CH4 alternate function on the
+// STM32N657 (per src/platform/STM32/timer_stm32n6xx.c, TIM1_CH3 is on
+// PA10/PE13 and TIM1_CH4 on PA11/PE14). M3/M4 will not PWM out as
+// configured — confirm against the v1.0 schematic and reassign before
+// flying.
+#define MOTOR1_PIN                      PE9     // TIM1_CH1
+#define MOTOR2_PIN                      PE11    // TIM1_CH2
+#define MOTOR3_PIN                      PD2     // TIM1_CH3 (TODO: invalid AF, see above)
+#define MOTOR4_PIN                      PC12    // TIM1_CH4 (TODO: invalid AF, see above)
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP(0, MOTOR1_PIN, 1, 0) \
+    TIMER_PIN_MAP(1, MOTOR2_PIN, 1, 1) \
+    TIMER_PIN_MAP(2, MOTOR3_PIN, 1, 2) \
+    TIMER_PIN_MAP(3, MOTOR4_PIN, 1, 3)

--- a/configs/STM32N657DK/config.h
+++ b/configs/STM32N657DK/config.h
@@ -29,10 +29,11 @@
 // the existing virtual drivers under src/main/drivers/{accgyro,compass,
 // barometer}/*_virtual.c.
 //
-// The LCD path is currently a placeholder backend (see
-// src/platform/STM32/lcd_ltdc_n6.c) that mirrors writes into a debug RAM
-// grid; real LTDC + PSRAM + DSI + RK050HR18 bring-up will replace the
-// placeholder over follow-up iterations on the actual board.
+// The LCD path uses the in-RAM stub backend (LCD_CONSOLE_PANEL_STUB):
+// writes land in a debug grid that the `lcd` CLI (and OpenOCD
+// `mdw stubGrid`) can dump. The bare DK has no panel attached — the
+// real LTDC panel backend (lcd_ltdc_n6.c) is exercised by the
+// STM32N657DK_DSK320 config when paired with the DSK320K daughter board.
 
 #define FC_TARGET_MCU                   STM32N657
 
@@ -61,12 +62,25 @@
 #define USE_MAG
 #define USE_VIRTUAL_MAG
 
+// --- USB VCP -------------------------------------------------------------
+// USB1 OTG_HS in FS mode on the user USB-C connector (PA11/PA12 internally
+// routed via the integrated PHY). USE_VCP is opted in per board because
+// the boot ROM hands off USB power-rail state non-deterministically and
+// each board does its own MspInit sequencing.
+#define USE_VCP
+
+// USE_ADC requires SystemClock_Config to set up the ADC kernel clock
+// (PERIPHCLK_ADC). The legacy STM32N657DK config didn't enable ADC, so
+// keep parity here until ADC clock setup lands per-board.
+
 // --- LCD console ---------------------------------------------------------
-// Route printf/trace output to the on-board LCD via the LTDC panel backend.
-// The CLI keeps its existing USB-VCP path; the LCD shows runtime/debug
-// output during normal operation.
+// Inherit the lcd_console framework with the in-RAM stub backend so
+// printf/trace output is captured into a debug grid that the `lcd` CLI
+// (and OpenOCD `mdw stubGrid`) can dump. A real LTDC panel backend is a
+// follow-up — until that lands, the CLI keeps its existing USB-VCP path
+// and the LCD path is purely a memory-resident scratchpad.
 #define ENABLE_LCD_CONSOLE              1
-#define LCD_CONSOLE_PANEL_LTDC
+#define LCD_CONSOLE_PANEL_STUB
 #define LCD_CONSOLE_COLS                80
 #define LCD_CONSOLE_ROWS                30
 #define ENABLE_LCD_PRINTF_REDIRECT      1

--- a/configs/STM32N657DK/config.mk
+++ b/configs/STM32N657DK/config.mk
@@ -1,4 +1,0 @@
-# STM32N6570-DK config — pulls in the LTDC panel backend for the LCD console.
-# Path is resolved against VPATH (which includes $(PLATFORM_DIR) i.e.
-# src/platform), so this expands to src/platform/STM32/lcd_ltdc_n6.c.
-TARGET_SRC += STM32/lcd_ltdc_n6.c

--- a/configs/STM32N657DK_DSK320/config.h
+++ b/configs/STM32N657DK_DSK320/config.h
@@ -1,0 +1,193 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// STM32N6570-DK + LSM6DSK320X (DSK320K) module bring-up config.
+//
+// Companion target: src/platform/STM32/target/STM32N657. The DSK320K module
+// is wired with the same pinout used on the NUCLEO-C562RE bring-up:
+//   SPI1   SCK PA5  / SDI PA6 / SDO PA7,  CS PC9,  DRDY/EXTI PA10
+//   I2C1   SCL PB6  / SDA PB7
+// Sensor stack on those buses: LSM6DSK320X gyro/accel (SPI1), LIS2MDL mag
+// + LPS22DF baro (I2C1).
+//
+// The on-board ST-LINK-V3 brings out USART1 PE5/PE6 for a backup serial
+// console. The MCU's own USB1 OTG_HS in FS mode (PA11/PA12) is exposed on
+// the user USB connector — used for the CLI/MSP VCP.
+//
+// USER LEDs available on the N6570-DK:
+//   LD1 green  PO1
+//   LD2 red    PG10
+//
+// SDCARD: SDMMCx instance + pins inherit defaults from the platform target.
+
+#define FC_TARGET_MCU                   STM32N657
+
+#define BOARD_NAME                      STM32N657DK_DSK320
+#define MANUFACTURER_ID                 STMI
+
+// XIP bring-up: skip flashInit + octoSpiInitDevice. The FSBL stub leaves
+// XSPI memory-mapped and BF runs XIP from it; we don't need BF to poke
+// the controller or probe the chip. Probing the wrong JEDEC ID
+// (W25Q128FV vs the actual MX66UW1G45G) was bus-faulting the chip out
+// of memory-mapped mode and locking up via double-fault.
+#define BF_N6_NO_FLASH_CHIP
+
+// HSE: drive SYSCLK/PLL1 from the on-board 48 MHz HSE. SystemClock_Config
+// in the platform translates SYSTEM_HSE_MHZ into the PLL1 N divider so the
+// VCO lands at the canonical 1200 MHz with CPU = 600 MHz via IC1.
+#define SYSTEM_HSE_MHZ                  48
+
+// Keep config in RAM during platform exploration so we sidestep the flash
+// partition path while bringing the board up. Switch to
+// CONFIG_IN_MEMORY_MAPPED_FLASH once the XSPI flash storage path is proven.
+#define CONFIG_IN_RAM
+
+// --- Sensors ------------------------------------------------------------
+// DSK320K module wiring (same pinout used on the NUCLEO-C562RE bring-up):
+//   SPI1   SCK PA5  / SDI PA6 / SDO PA7,  LSM6DSK320X CS PC9 / DRDY PA10
+//   I2C1   SCL PB6  / SDA PB7,  LIS2MDL mag + LPS22DF baro
+//
+// Real sensors stay disabled until the N6 SPI/I2C bring-up handles the
+// RIF + secure peripheral alias correctly (without -mcmse, peripheral
+// symbols resolve to the NS aliases at 0x42xxxxxx and the bus matrix
+// faults the access). Use the virtual stack so the scheduler runs.
+#define USE_ACC
+#define USE_VIRTUAL_ACC
+#define USE_GYRO
+#define USE_VIRTUAL_GYRO
+#define USE_BARO
+#define USE_VIRTUAL_BARO
+#define USE_MAG
+#define USE_VIRTUAL_MAG
+
+// Real sensor pin defs kept here for the next iteration:
+// #define USE_ACCGYRO_LSM6DSK320X
+// #define USE_GYRO_EXTI
+// #define USE_SPI_DEVICE_1
+// #define SPI1_SCK_PIN                    PA5
+// #define SPI1_SDI_PIN                    PA6
+// #define SPI1_SDO_PIN                    PA7
+// #define GYRO_1_SPI_INSTANCE             SPI1
+// #define GYRO_1_CS_PIN                   PC9
+// #define GYRO_1_EXTI_PIN                 PA10
+// #define GYRO_1_ALIGN                    CW180_DEG
+// #define USE_MAG_LIS2MDL
+// #define USE_BARO_LPS22DF
+// #define USE_I2C_DEVICE_1
+// #define I2C1_SCL_PIN                    PB6
+// #define I2C1_SDA_PIN                    PB7
+// #define MAG_I2C_INSTANCE                I2CDEV_1
+// #define BARO_I2C_INSTANCE               I2CDEV_1
+// #define MAG_ALIGN                       CW0_DEG
+
+// --- ST-LINK V3 VCOM (USART1 PE5/PE6) -----------------------------------
+// The N6570-DK routes USART1 PE5/PE6 to the on-board ST-LINK-V3 VCOM.
+// Left undefined so MSP/CLI runs only on the USB VCP. Re-enable manually
+// (USE_UART1 + UART1_TX_PIN/UART1_RX_PIN, optionally MSP_UART) if you
+// want a serial backup path.
+// #define USE_UART1
+// #define UART1_TX_PIN                    PE5
+// #define UART1_RX_PIN                    PE6
+// #define MSP_UART                        SERIAL_PORT_USART1
+
+// --- ADC ----------------------------------------------------------------
+// Bring up ADC1 with VBAT on PB0 (ADC1 channel 8). Nothing is wired to
+// PB0 by default on the N6570-DK, so the reading will be floating /
+// near-zero — the goal here is just to exercise the ADC code path so the
+// `Voltage` line in `status` reflects a real conversion.
+//
+// SystemClock_Config already configures the ADC kernel clock at HCLK/2
+// (75 MHz, within the 75 MHz max).
+//
+// `validateAndFixConfig` syncs `adcConfig.vbat.enabled` from
+// `batteryConfig.voltageMeterSource`, which defaults to NONE upstream.
+// Override to ADC so the default config has vbat sampling enabled —
+// otherwise the live `vbat.enabled` is forced false even when
+// `ADC_VBAT_PIN` is defined.
+#define ADC_VBAT_PIN                    PB0
+#define ADC_INSTANCE                    ADC1
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+
+// --- USB VCP ------------------------------------------------------------
+// USB1 OTG_HS in FS mode (PA11 D-/PA12 D+) routed to the user USB-C
+// connector. SystemClock_Config feeds the USB1 PHY from HSE/2 (24 MHz),
+// and HAL_PCD_MspInit (in usbd_conf_stm32n6xx.c) primes VddUSBVMEN +
+// USB33RDY before the core leaves reset.
+#define USE_VCP
+
+// --- Status LEDs --------------------------------------------------------
+// N6570-DK user LEDs: LD1 (red / PO1) → LED0; LD2 (green / PG10) → LED1.
+// LED1 is the run-loop heartbeat (LED1_TOGGLE in main.c::run); LED0 is
+// driven by BF's standard arming-disabled warning indicator. The IO
+// subsystem reaches port O via the extended io_def_generated coverage
+// (A..O); ports P and Q remain unreachable until ioTag_t widens past
+// uint8_t.
+#define LED0_PIN                        PO1
+#define LED1_PIN                        PG10
+
+// --- SDCARD (on-board microSD slot) ------------------------------------
+// SDMMC2 routed to all six lines via the on-board card cage. Pin map per
+// CubeN6 STM32N6570-DK SD/SD_ReadWrite_DMA example (all AF11):
+//   CK  PC2   CMD PC3
+//   D0  PC4   D1  PC5   D2 PC0   D3 PE4
+//
+// HAL_SD_MspInit now configures the SDMMC2 master+slave RIF attributes and
+// marks each pin as secure-privileged. HAL_SD_Init still spin-loops on the
+// SDMMC STAR register (offset 0x34), so something else in the controller
+// init path needs attention (possibly the DLYB / OUTDRV / CKIN gating
+// outside the RIF framework). Pin/RIF infrastructure is committed for the
+// follow-up — leave USE_SDCARD off until HAL_SD_Init returns cleanly.
+// #define USE_SDCARD
+// #define SDIO_DEVICE                     SDIODEV_2
+// #define SDIO_USE_4BIT                   true
+// #define SDIO_CK_PIN                     PC2
+// #define SDIO_CMD_PIN                    PC3
+// #define SDIO_D0_PIN                     PC4
+// #define SDIO_D1_PIN                     PC5
+// #define SDIO_D2_PIN                     PC0
+// #define SDIO_D3_PIN                     PE4
+
+// --- Motors -------------------------------------------------------------
+// MOTOR1..4 placeholder. The N6570-DK exposes its Arduino-style headers
+// (Zio + Arduino Uno V3) — pick four pins with a timer output channel and
+// no conflict with the SPI1 / I2C1 / USB / LED / SDMMC assignments above.
+// Filled in once the BSP pin survey lands.
+//
+// #define MOTOR1_PIN                   ...
+// #define MOTOR2_PIN                   ...
+// #define MOTOR3_PIN                   ...
+// #define MOTOR4_PIN                   ...
+//
+// TIMER_PIN_MAPPING entries are required alongside the pin defines so
+// fullTimerHardware resolves a timer/channel for each motor pin during
+// DSHOT bitbang init.
+
+// --- LCD console ---------------------------------------------------------
+// LTDC backend (lcd_panel_n6570dk_ltdc.c) currently wedges the boot path
+// between systemInit() and USB init, blocking USB enumeration. Off until
+// the bring-up sequence is fixed; the panel driver source stays in the
+// build tree and self-disables when the selector is undefined.
+#define ENABLE_LCD_CONSOLE              0
+
+// 4 kHz PID loop at the default 8 kHz gyro rate.
+#define DEFAULT_PID_PROCESS_DENOM       2


### PR DESCRIPTION
N6 platform bring-up follow-on, layering on top of the merged STM32N657DK config (#1086).

## Configs

**STM32N657DK_DSK320** — N6570-DK paired with the DSK320K display add-on board. Carries:
- USART1 on PE5/PE6 (ST-LINK V3 VCOM) for default MSP transport
- LD1 (PO1 green) promoted to LED0; PG10 stays as LED1
- LTDC LCD console backend (`N6570DK_LTDC`) inherited via the lcd_console subsystem
- ADC1 enabled with VBAT on PB0
- Real on-board sensors and SD card kept gated off until SPI/I2C/SDMMC2 N6 bring-up lands
- LCD console toggled off in the latest commit pending bring-up investigation

**OPENN657V1** — open-hardware STM32N657 flight controller v1.0 (using the `CUST` custom-config manufacturer ID). Carries:
- ICM-42688P IMU on SPI1 (CS PE2, EXTI PA3, CW180)
- 4 motors on TIM1: PE9 / PE11 / PD2 / PC12
- UART3 bidir, UART4 SBUS RX, UART5/6 RX pads
- LEDs PD15 + PG10
- 48 MHz HSE, CONFIG_IN_RAM (no internal user flash on N6)
- BMP280 baro stays behind a TODO — fork target.h enabled all four I2C buses but never assigned SCL/SDA, so wiring needs schematic confirmation

Also includes a shared commit that wires the lcd_console framework into both N6 dev configs with the in-RAM stub backend.

## Caveats

- Depends on the N6 platform work in progress on `betaflight/betaflight` (`feat/n6570dk` branch). Won't build green on CI here until that platform PR lands.
- Pushed primarily so collaborators can fetch and test against the N6 platform branch in parallel; not asking for merge yet.

## Test plan
- [ ] Build STM32N657DK_DSK320 against the matching `betaflight/betaflight feat/n6570dk` tip
- [ ] Build OPENN657V1 against the same
- [ ] Confirm SBUS RX, motor PWM, IMU detect on OPENN657V1 once SPI bring-up exits
- [ ] Confirm LTDC console + ST-LINK VCOM on N657DK_DSK320 once LCD bring-up lands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for OPENN657V1 flight controller with onboard IMU, USB VCP, LED and motor pin mappings.
  * Added support for STM32N657DK_DSK320 development board with RAM-only bring-up, ADC/VBAT, LEDs and virtual sensor modes.

* **Configuration Updates**
  * Enabled USB Virtual COM Port on STM32N657DK.
  * Switched STM32N657DK LCD console to an in-RAM stub backend for easier debug output capture.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/config/pull/1096)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->