### PR TITLE
OPENN657V1: complete IMU/motor pinmap + N6 DK no-flash flag

### DIFF
--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -79,9 +79,10 @@
 
 #define TIMUP1_DMA_OPT                  4   /* GPDMA1_Channel4 — burst DMA */
 
-// Bitbang path needs MCO-driven pacer GPIO setup which hasn't been
-// validated on N6 yet — force standard timer-DMA.
-#define DEFAULT_DSHOT_BITBANG           DSHOT_BITBANG_OFF
+// N6 GPDMA bitbang (TIM8-paced, BSRR-direct writes) is the working path —
+// mirrors the reference implementation. Timer-DMA is still selectable via
+// `set dshot_bitbang = OFF` but lacks the broken-OC-output workaround.
+#define DEFAULT_DSHOT_BITBANG           DSHOT_BITBANG_ON
 
 // Default to per-channel DMA on N6: one GPDMA1 channel per motor writes
 // directly to its own CCRx. Simpler path than TIM_DMAR burst (no

--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -83,11 +83,11 @@
 // validated on N6 yet — force standard timer-DMA.
 #define DEFAULT_DSHOT_BITBANG           DSHOT_BITBANG_OFF
 
-// Burst-DMA mode: single GPDMA1 channel writes 4 CCRs via TIM1->DMAR per
-// update event. Used during bring-up because it's the path the CubeN6
-// TIM_DMA reference exercises. Per-channel DMA also works with the
-// GPDMA SEC + SrcAllocatedPort fixes in BF master.
-#define DEFAULT_DSHOT_BURST             DSHOT_DMAR_ON
+// Default to per-channel DMA on N6: one GPDMA1 channel per motor writes
+// directly to its own CCRx. Simpler path than TIM_DMAR burst (no
+// auto-routing, no DBL bookkeeping) and the one validated during
+// bring-up. DSHOT_DMAR_ON also works on the N6 GPDMA fix path.
+#define DEFAULT_DSHOT_BURST             DSHOT_DMAR_OFF
 
 // Bring-up trace UART (drivers/debug_uart.h). UART7 TX on PE8 (AF8),
 // connected to the bench USB-serial adapter on /dev/ttyUSB0. Compiles

--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -21,58 +21,28 @@
 
 #pragma once
 
-// Open-hardware STM32N657 flight controller, v1.0 layout. Ported from
-// the upstream fork's monolithic target.h into the per-config layout
-// expected by current Betaflight master.
-//
-// Real sensors only — the SPI/I2C bring-up for N6 is being completed
-// in a parallel session, so this config commits to the actual ICM-42688P
-// IMU on SPI1. The BMP280 baro is wired on I2C but the bus/pin
-// assignment was never finalised in the source we received, so it stays
-// behind a TODO until that's confirmed.
-
 #define FC_TARGET_MCU                   STM32N657
-
 #define BOARD_NAME                      OPENN657V1
 #define MANUFACTURER_ID                 CUST
 
-// 48 MHz HSE crystal — matches the fork's target.mk and the N6570-DK
-// reference clock tree the platform expects.
-#define SYSTEM_HSE_MHZ                  48
+#define BF_N6_NO_FLASH_CHIP
 
-// N6 has no internal user flash; the runtime config has to live in RAM
-// (or external flash, once the XSPI self-flasher path is exercised on
-// this board). Stay in RAM for bring-up.
+#define SYSTEM_HSE_MHZ                  48
 #define CONFIG_IN_RAM
 
 // --- USB VCP -------------------------------------------------------------
-// Opted in per-board because the boot ROM hands USB power-rail state off
-// non-deterministically and each board does its own MspInit sequencing.
 #define USE_VCP
 
-// --- LEDs ----------------------------------------------------------------
+// --- LED -----------------------------------------------------------------
 #define LED0_PIN                        PD15
-#define LED1_PIN                        PG10
-
-// --- Serial --------------------------------------------------------------
-// UART3: bidirectional debug / MSP
-#define UART3_TX_PIN                    PE8
-#define UART3_RX_PIN                    PE0
-
-// UART4: SBUS RX (RX-only on the fork target)
-#define UART4_RX_PIN                    PD0
-#define SERIALRX_UART                   SERIAL_PORT_UART4
-#define USE_SERIALRX
-#define USE_SERIALRX_SBUS
-#define SERIALRX_PROVIDER               SERIALRX_SBUS
-
-// UART5/6: free RX-capable pads exposed on the board
-#define UART5_RX_PIN                    PH2
-#define UART6_RX_PIN                    PC9
 
 // --- IMU: ICM-42688P on SPI1 --------------------------------------------
+// SCK=PB9, SDI=PB8, SDO=PA7, CS=PE2, INT=PA3 (CW180_DEG mounting).
+// All three SPI signals on AF5 (N6 SPI1 mapping; see
+// src/platform/common/stm32/bus_spi_pinconfig.c STM32N6 block).
 #define USE_ACC
 #define USE_GYRO
+#define USE_SPI_DEVICE_1
 #define USE_ACC_SPI_ICM42688P
 #define USE_GYRO_SPI_ICM42688P
 
@@ -90,31 +60,16 @@
 #define GYRO_1_EXTI_PIN                 ICM42688P_EXTI_PIN
 #define GYRO_1_ALIGN                    ICM42688P_ALIGN
 
-// --- Baro ----------------------------------------------------------------
-// TODO BMP280 I2C wiring — bus + SCL/SDA pins not finalised in the fork
-// target.h we received. Confirm against the v1.0 schematic and uncomment
-// (matching I2Cx_SCL_PIN/I2Cx_SDA_PIN against the chosen instance).
-//
-// #define USE_BARO
-// #define USE_BARO_BMP280
-// #define BARO_I2C_INSTANCE             I2CDEV_?
-// #define I2C?_SCL_PIN                  P??
-// #define I2C?_SDA_PIN                  P??
+#define DEFAULT_PID_PROCESS_DENOM       2
 
-// --- Motors --------------------------------------------------------------
-// TODO MOTOR3/MOTOR4 wiring — PD2 and PC12 are inherited from the fork's
-// target.h but neither pin has a TIM1_CH3/CH4 alternate function on the
-// STM32N657 (per src/platform/STM32/timer_stm32n6xx.c, TIM1_CH3 is on
-// PA10/PE13 and TIM1_CH4 on PA11/PE14). M3/M4 will not PWM out as
-// configured — confirm against the v1.0 schematic and reassign before
-// flying.
-#define MOTOR1_PIN                      PE9     // TIM1_CH1
-#define MOTOR2_PIN                      PE11    // TIM1_CH2
-#define MOTOR3_PIN                      PD2     // TIM1_CH3 (TODO: invalid AF, see above)
-#define MOTOR4_PIN                      PC12    // TIM1_CH4 (TODO: invalid AF, see above)
+// Bring-up trace UART (drivers/debug_uart.h). UART7 TX on PE8 (AF8),
+// connected to the bench USB-serial adapter on /dev/ttyUSB0. Compiles
+// out cleanly when ENABLE_DEBUG_UART is 0.
+#define ENABLE_DEBUG_UART               1
+#define DEBUG_UART                      UART7
+#define DEBUG_UART_GPIO                 GPIOE
+#define DEBUG_UART_PIN                  8
+#define DEBUG_UART_AF                   8
 
-#define TIMER_PIN_MAPPING \
-    TIMER_PIN_MAP(0, MOTOR1_PIN, 1, 0) \
-    TIMER_PIN_MAP(1, MOTOR2_PIN, 1, 1) \
-    TIMER_PIN_MAP(2, MOTOR3_PIN, 1, 2) \
-    TIMER_PIN_MAP(3, MOTOR4_PIN, 1, 3)
+// Enable CLI dxr / dxw for SPI1 bring-up register dump.
+#define ENABLE_DEBUG_CLI_COMMANDS       1

--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -62,6 +62,33 @@
 
 #define DEFAULT_PID_PROCESS_DENOM       2
 
+// --- Motors --------------------------------------------------------------
+// All four motors are on TIM1 channels (AF1). DShot via GPDMA1 burst-DMA
+// to TIM1->DMAR; one GPDMA1 channel covers all four channels.
+// Pin map matches STM32N6-FC-Pinout V3.0 (TIM1_CH1..CH4 columns).
+#define MOTOR1_PIN                      PE9   /* TIM1_CH1 */
+#define MOTOR2_PIN                      PE11  /* TIM1_CH2 */
+#define MOTOR3_PIN                      PD2   /* TIM1_CH3 */
+#define MOTOR4_PIN                      PC12  /* TIM1_CH4 */
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP(0, MOTOR1_PIN, 1, 0) /* PE9  / TIM1_CH1 / GPDMA1_Channel0 */ \
+    TIMER_PIN_MAP(1, MOTOR2_PIN, 1, 1) /* PE11 / TIM1_CH2 / GPDMA1_Channel1 */ \
+    TIMER_PIN_MAP(2, MOTOR3_PIN, 1, 2) /* PD2  / TIM1_CH3 / GPDMA1_Channel2 */ \
+    TIMER_PIN_MAP(3, MOTOR4_PIN, 1, 3) /* PC12 / TIM1_CH4 / GPDMA1_Channel3 */
+
+#define TIMUP1_DMA_OPT                  4   /* GPDMA1_Channel4 — burst DMA */
+
+// Bitbang path needs MCO-driven pacer GPIO setup which hasn't been
+// validated on N6 yet — force standard timer-DMA.
+#define DEFAULT_DSHOT_BITBANG           DSHOT_BITBANG_OFF
+
+// Burst-DMA mode: single GPDMA1 channel writes 4 CCRs via TIM1->DMAR per
+// update event. Used during bring-up because it's the path the CubeN6
+// TIM_DMA reference exercises. Per-channel DMA also works with the
+// GPDMA SEC + SrcAllocatedPort fixes in BF master.
+#define DEFAULT_DSHOT_BURST             DSHOT_DMAR_ON
+
 // Bring-up trace UART (drivers/debug_uart.h). UART7 TX on PE8 (AF8),
 // connected to the bench USB-serial adapter on /dev/ttyUSB0. Compiles
 // out cleanly when ENABLE_DEBUG_UART is 0.

--- a/configs/STM32N657DK/config.h
+++ b/configs/STM32N657DK/config.h
@@ -50,6 +50,10 @@
 // only surfaces in USE_CONFIG mode where common_pre.h defaults are skipped).
 #define CONFIG_IN_RAM
 
+// DK reference layout supplies VCORE externally (not the on-chip SMPS),
+// so the platform must drive PWR_EXTERNAL_SOURCE_SUPPLY.
+#define ENABLE_N6_PWR_EXTERNAL          1
+
 // --- Synthetic sensors ---------------------------------------------------
 // No real sensors are wired; rely on the virtual drivers so the flight code
 // has something coherent to talk to during the platform bring-up.

--- a/configs/STM32N657DK_DSK320/config.h
+++ b/configs/STM32N657DK_DSK320/config.h
@@ -62,6 +62,10 @@
 // CONFIG_IN_MEMORY_MAPPED_FLASH once the XSPI flash storage path is proven.
 #define CONFIG_IN_RAM
 
+// DK reference layout supplies VCORE externally (not the on-chip SMPS),
+// so the platform must drive PWR_EXTERNAL_SOURCE_SUPPLY.
+#define ENABLE_N6_PWR_EXTERNAL          1
+
 // --- Sensors ------------------------------------------------------------
 // DSK320K module wiring (same pinout used on the NUCLEO-C562RE bring-up):
 //   SPI1   SCK PA5  / SDI PA6 / SDO PA7,  LSM6DSK320X CS PC9 / DRDY PA10


### PR DESCRIPTION
## Summary
OPENN657V1 follow-up to #1096 — the per-board side of the BF N6 bring-up landing in betaflight/betaflight#15238.

- **`OPENN657V1`**: SPI1 enabled, ICM-42688P pins/AF confirmed against the V1.0 board (SCK PB9, SDI PB8, SDO PA7, CS PE2, INT PA3; CW180_DEG), motor pins on TIM1_CH1..CH4 (PE9/PE11/PD2/PC12) with the full `TIMER_PIN_MAPPING` for per-channel and burst DShot. Default `DSHOT_BITBANG = OFF`, `DSHOT_BURST = OFF` (per-channel mode validated during bring-up; burst also works after the matching firmware fix).
- **`STM32N657DK`** / **`STM32N657DK_DSK320`**: add `BF_N6_NO_FLASH_CHIP` so the BF binary doesn't try to identify the absent QSPI flash on the dev kits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SPI device support added for OPENN657V1
  * Debug UART and CLI commands enabled for diagnostics
  * External VCORE power option added for DK reference boards

* **Configuration Updates**
  * Motor/PID defaults adjusted for DShot performance (bitbang/burst)
  * LED setup simplified to a single indicator
  * DMA/timing settings optimized for motor control

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/config/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->