### PR TITLE
OPENN657V1: enable BMP280 baro on I2C1

### DIFF
--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -72,14 +72,9 @@
 #define I2C1_SCL_PIN                    PH9
 #define I2C1_SDA_PIN                    PC1
 
-// USE_BARO disabled — board has a BMP280 on I2C1 but BF's async baro
-// state machine wedges the scheduler on N6 (the I2C BUSY-after-NACK
-// pattern that the existing recovery code doesn't fully escape from).
-// Re-enable once the N6 I2C driver / baro state machine recovery is
-// fixed.
-// #define USE_BARO
-// #define USE_BARO_BMP280
-// #define BARO_I2C_INSTANCE               I2CDEV_1
+#define USE_BARO
+#define USE_BARO_BMP280
+#define BARO_I2C_INSTANCE               I2CDEV_1
 
 // --- Motors --------------------------------------------------------------
 // All four motors are on TIM1 channels (AF1). DShot via GPDMA1 burst-DMA

--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -72,9 +72,14 @@
 #define I2C1_SCL_PIN                    PH9
 #define I2C1_SDA_PIN                    PC1
 
-#define USE_BARO
-#define USE_BARO_BMP280
-#define BARO_I2C_INSTANCE               I2CDEV_1
+// USE_BARO disabled — board has a BMP280 on I2C1 but BF's async baro
+// state machine wedges the scheduler on N6 (the I2C BUSY-after-NACK
+// pattern that the existing recovery code doesn't fully escape from).
+// Re-enable once the N6 I2C driver / baro state machine recovery is
+// fixed.
+// #define USE_BARO
+// #define USE_BARO_BMP280
+// #define BARO_I2C_INSTANCE               I2CDEV_1
 
 // --- Motors --------------------------------------------------------------
 // All four motors are on TIM1 channels (AF1). DShot via GPDMA1 burst-DMA

--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -65,6 +65,17 @@
 
 #define DEFAULT_PID_PROCESS_DENOM       2
 
+// --- Baro: BMP280 on I2C1 ------------------------------------------------
+// SCL=PH9, SDA=PC1 (AF4). Default I2C address 0x76 (SDO tied low).
+// (USE_I2C is provided by the N657 target.h.)
+#define USE_I2C_DEVICE_1
+#define I2C1_SCL_PIN                    PH9
+#define I2C1_SDA_PIN                    PC1
+
+#define USE_BARO
+#define USE_BARO_BMP280
+#define BARO_I2C_INSTANCE               I2CDEV_1
+
 // --- Motors --------------------------------------------------------------
 // All four motors are on TIM1 channels (AF1). DShot via GPDMA1 burst-DMA
 // to TIM1->DMAR; one GPDMA1 channel covers all four channels.
@@ -104,3 +115,7 @@
 
 // Enable CLI dxr / dxw for SPI1 bring-up register dump.
 #define ENABLE_DEBUG_CLI_COMMANDS       1
+
+// Don't write fresh defaults to MM-flash on first-boot EEPROM recovery.
+// The save path stalls the scheduler for ~7 s mid-initPhase1.
+#define ENABLE_RESET_CONFIG             1

--- a/configs/OPENN657V1/config.h
+++ b/configs/OPENN657V1/config.h
@@ -25,10 +25,13 @@
 #define BOARD_NAME                      OPENN657V1
 #define MANUFACTURER_ID                 CUST
 
-#define BF_N6_NO_FLASH_CHIP
-
 #define SYSTEM_HSE_MHZ                  48
-#define CONFIG_IN_RAM
+
+// CLI `save` writes config into the boot flash chip (mx66uw1g45g) at the
+// top of XSPI2 via the meta-flash driver. The OCTOSPI_FLASH_CHIP setting
+// in config.mk pairs with this — without it the build-time chip dispatch
+// in flash.c can't select the chip and detection falls back to JEDEC
+// probing (which the bootloader-configured MX66 doesn't honour cleanly).
 
 // --- USB VCP -------------------------------------------------------------
 #define USE_VCP

--- a/configs/OPENN657V1/config.mk
+++ b/configs/OPENN657V1/config.mk
@@ -1,0 +1,5 @@
+# Boot flash chip on OPENN657V1 is Macronix MX66UW1G45G (1 Gbit octal NOR).
+# The OpenBootloader leaves it in 1S-1S-1S mode for BF; flash.c uses
+# build-time selection (OCTOSPI_FLASH_CHIP_<chip>) because the chip
+# cannot answer 1/4-line JEDEC RDID while configured for OPI.
+OCTOSPI_FLASH_CHIP := MX66UW1G45G


### PR DESCRIPTION
Re-enables `USE_BARO`/`USE_BARO_BMP280` on the on-board BMP280 (I2C1,
PH9/PC1, addr 0x76 with 0x77 fallback). The async-I2C state-machine
wedge that previously blocked this lands as a CR1 RMW-race fix in
`bus_i2c_ll` on the BF side.

CLI `status` after the BF fix lands reports `BARO: BMP280`, TASK_BARO
runs cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Barometer sensor support enabled for environmental monitoring, atmospheric pressure measurement, and altitude tracking.
  * Device reset and configuration recovery features now available to simplify device management and system recovery.

* **Chores**
  * Flash memory configuration updated for enhanced hardware compatibility and device reliability.
  * Unused configuration flags removed to streamline device initialization and setup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->