### PR TITLE
FLYWOOF722PROV2 : Add BMI270 Gyro Support

### DIFF
--- a/configs/FLYWOOF722PROV2/config.h
+++ b/configs/FLYWOOF722PROV2/config.h
@@ -28,6 +28,7 @@
 #define USE_FLASH
 #define USE_GYRO
 
+#define USE_ACCGYRO_BMI270
 #define USE_ACC_SPI_ICM42688P
 #define USE_BARO_DPS310
 #define USE_FLASH_W25Q128FV


### PR DESCRIPTION
FLYWOOF722PROV2 : Add BMI270 Gyro Support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled BMI270 accelerometer/gyro sensor support for the FLYWOOF722PROV2 board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->