### PR TITLE
Add ARCROBO_C562V1 (STM32C562) flight controller

### DIFF
--- a/configs/ARCROBO_C562V1/config.h
+++ b/configs/ARCROBO_C562V1/config.h
@@ -81,7 +81,9 @@
 // SPA06-003 baro over I3C1 (PC10=SCL/PC11=SDA, AF4). First-cut probe; the
 // real driver is still to land. Probe reads CHIP_ID and parks the result for
 // SWD inspection.
-#define ENABLE_BARO_SPA06_PROBE         1
+// Probe disabled now that the I3C-as-I2C driver handles bring-up via BF's
+// bus_i2c framework. Re-enable to diagnose if baro detection breaks.
+#define ENABLE_BARO_SPA06_PROBE         0
 
 // --- External flash: W25Q128JV on SPI1 -----------------------------------
 // AF5 standard for SPI1 on STM32C5.
@@ -114,12 +116,23 @@
 // path (same trap as OPENC5A3V1).
 #define USE_OSD_SD
 
-// --- Baro: virtual ------------------------------------------------------
-// Schematic labels PC10/PC11 as I2C3 SCL/SDA, but C562 has no I2C3
-// peripheral -- PC10/PC11 are I3C1 alternates and BF has no
-// I3C-as-I2C driver yet. Stay on virtual baro for first light.
+// --- Baro: SPA06-003 over I3C1-as-I2C ------------------------------------
+// Schematic labels PC10/PC11 as I2C3 SCL/SDA but C562 has no I2C3 peripheral
+// -- those pads are I3C1-only (AF4). USE_I3C_AS_I2C activates the
+// bus_i2c_i3c.c driver which runs I3C1 in MTYPE_LEGACY_I2C controller mode
+// with the I3C arbitration header suppressed, presenting a plain bus_i2c.h
+// interface to the rest of BF. The SPA06-003 (CHIP_ID 0x11, register-
+// identical to SPL07-003) is picked up by the DPS310 driver; the
+// USE_BARO_SPA06_003 alias surfaces the correct chip name in status/CLI.
 #define USE_BARO
-#define USE_VIRTUAL_BARO
+#define USE_BARO_SPA06_003
+#define USE_I2C
+#define USE_I3C_AS_I2C
+#define USE_I2C_DEVICE_1
+#define I3C_AS_I2C_SCL_PIN              PC10
+#define I3C_AS_I2C_SDA_PIN              PC11
+#define BARO_I2C_INSTANCE               I2CDEV_1
+#define DEFAULT_BARO_I2C_ADDRESS        0x76
 
 // --- Mag still synthetic -------------------------------------------------
 #define USE_MAG
@@ -146,7 +159,6 @@
     TIMER_PIN_MAP(3, PC9, 1, -1) \
     TIMER_PIN_MAP(4, PA8, 1, -1)
 
-#define DEFAULT_PID_PROCESS_DENOM       2
 
 // --- ADC: VBAT + current + RSSI ------------------------------------------
 // PC1/PC2/PC3 are ADC1/ADC2 channels 11/12/13 per the C5 ADC pin table.

--- a/configs/ARCROBO_C562V1/config.h
+++ b/configs/ARCROBO_C562V1/config.h
@@ -1,0 +1,155 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// ARCROBO_C562V1 -- Arcrobo hand-built FC, STM32C562RET6 in LQFP64.
+// Schematic: ~/src/ref/C562/STM32C562_SCH_V1.0-20260409.pdf
+
+#define FC_TARGET_MCU                   STM32C562
+
+#define BOARD_NAME                      ARCROBO_C562V1
+#define MANUFACTURER_ID                 ACRO
+
+// HSE 8 MHz crystal on PH0/PH1 (Y1)
+#define SYSTEM_HSE_MHZ                  8
+
+// Config in W25Q128 on SPI1.
+#define CONFIG_IN_EXTERNAL_FLASH
+
+// --- USB VCP -------------------------------------------------------------
+#define USE_VCP
+#define USB_DETECT_PIN                  PC0
+#define USE_USB_DETECT
+
+// --- Status LED ----------------------------------------------------------
+#define LED0_PIN                        PE2
+
+// --- UART pin map --------------------------------------------------------
+#define UART1_TX_PIN                    PA9
+#define UART1_RX_PIN                    PA10
+#define UART2_TX_PIN                    PA2
+#define UART2_RX_PIN                    PA3
+#define UART3_TX_PIN                    PB10
+#define UART3_RX_PIN                    PC4
+#define UART4_TX_PIN                    PA0
+#define UART4_RX_PIN                    PA1
+#define UART5_TX_PIN                    PC12
+#define UART5_RX_PIN                    PD2
+
+// --- IMU: ICM-42688P on SPI3 ---------------------------------------------
+// SPI3 SCK=PB9, MISO=PB6, MOSI=PB5 (AF7 -- C5 quirk patched in #15284),
+// CS=PB8, INT/DRDY=PB7.
+#define USE_ACC
+#define USE_GYRO
+#define USE_GYRO_EXTI
+
+#define USE_SPI_DEVICE_3
+#define SPI3_SCK_PIN                    PB9
+#define SPI3_SDI_PIN                    PB6
+#define SPI3_SDO_PIN                    PB5
+
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
+
+#define ICM42688P_SPI_INSTANCE          SPI3
+#define ICM42688P_CS_PIN                PB8
+#define ICM42688P_EXTI_PIN              PB7
+#define ICM42688P_ALIGN                 CW0_DEG
+
+#define GYRO_1_SPI_INSTANCE             ICM42688P_SPI_INSTANCE
+#define GYRO_1_CS_PIN                   ICM42688P_CS_PIN
+#define GYRO_1_EXTI_PIN                 ICM42688P_EXTI_PIN
+#define GYRO_1_ALIGN                    ICM42688P_ALIGN
+
+// --- External flash: W25Q128JV on SPI1 -----------------------------------
+// AF5 standard for SPI1 on STM32C5.
+#define USE_SPI_DEVICE_1
+#define SPI1_SCK_PIN                    PA5
+#define SPI1_SDI_PIN                    PA6
+#define SPI1_SDO_PIN                    PA7
+
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define FLASH_SPI_INSTANCE              SPI1
+#define FLASH_CS_PIN                    PA4
+
+#define USE_FLASHFS
+#define USE_BLACKBOX
+
+// --- OSD: AT7456E on SPI2 ------------------------------------------------
+#define USE_SPI_DEVICE_2
+#define SPI2_SCK_PIN                    PB13
+#define SPI2_SDI_PIN                    PB14
+#define SPI2_SDO_PIN                    PB15
+
+#define USE_MAX7456
+#define MAX7456_SPI_INSTANCE            SPI2
+#define MAX7456_SPI_CS_PIN              PB12
+
+#define USE_OSD
+// AT7456E is SD-only OSD; declare USE_OSD_SD so common_pre.h does
+// not auto-define USE_OSD_HD and short-circuit init.c to the MSP OSD
+// path (same trap as OPENC5A3V1).
+#define USE_OSD_SD
+
+// --- Baro: virtual ------------------------------------------------------
+// Schematic labels PC10/PC11 as I2C3 SCL/SDA, but C562 has no I2C3
+// peripheral -- PC10/PC11 are I3C1 alternates and BF has no
+// I3C-as-I2C driver yet. Stay on virtual baro for first light.
+#define USE_BARO
+#define USE_VIRTUAL_BARO
+
+// --- Mag still synthetic -------------------------------------------------
+#define USE_MAG
+#define USE_VIRTUAL_MAG
+
+// --- Motors: DShot bitbang on TIM8 ---------------------------------------
+// M1 PC6 / M2 PC7 / M3 PC8 / M4 PC9.
+#define MOTOR1_PIN                      PC6
+#define MOTOR2_PIN                      PC7
+#define MOTOR3_PIN                      PC8
+#define MOTOR4_PIN                      PC9
+
+// --- LED strip on PA8 (TIM1_CH1) -----------------------------------------
+#define USE_LED_STRIP
+#define LED_STRIP_PIN                   PA8
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP(0, PC6, 2, -1) \
+    TIMER_PIN_MAP(1, PC7, 2, -1) \
+    TIMER_PIN_MAP(2, PC8, 2, -1) \
+    TIMER_PIN_MAP(3, PC9, 2, -1) \
+    TIMER_PIN_MAP(4, PA8, 1, -1)
+
+#define DEFAULT_PID_PROCESS_DENOM       2
+
+// --- ADC: VBAT + current + RSSI ------------------------------------------
+#define ADC_VBAT_PIN                    PC1
+#define ADC_CURR_PIN                    PC2
+#define ADC_RSSI_PIN                    PC3
+#define ADC1_INSTANCE                   ADC1
+
+// --- Buzzer --------------------------------------------------------------
+// Passive buzzer driven by PC5 via Q1 MOSFET (inverted).
+#define USE_BEEPER
+#define BEEPER_PIN                      PC5
+#define BEEPER_INVERTED

--- a/configs/ARCROBO_C562V1/config.h
+++ b/configs/ARCROBO_C562V1/config.h
@@ -67,18 +67,21 @@
 #define SPI3_SDI_PIN                    PB6
 #define SPI3_SDO_PIN                    PB5
 
-#define USE_ACC_SPI_ICM42688P
-#define USE_GYRO_SPI_ICM42688P
+// The IMU populated on this board is an LSM6 family part (WHO_AM_I=0x75 at
+// reg 0x0F), matched by BF's LSM6DSK320X driver. Schematic markings refer to
+// it as ICM-42688P but the silicon is LSM6 -- different register map, so the
+// LSM6 driver path is what actually drives it.
+#define USE_ACCGYRO_LSM6DSK320X
 
-#define ICM42688P_SPI_INSTANCE          SPI3
-#define ICM42688P_CS_PIN                PB8
-#define ICM42688P_EXTI_PIN              PB7
-#define ICM42688P_ALIGN                 CW0_DEG
+#define GYRO_1_SPI_INSTANCE             SPI3
+#define GYRO_1_CS_PIN                   PB8
+#define GYRO_1_EXTI_PIN                 PB7
+#define GYRO_1_ALIGN                    CW0_DEG
 
-#define GYRO_1_SPI_INSTANCE             ICM42688P_SPI_INSTANCE
-#define GYRO_1_CS_PIN                   ICM42688P_CS_PIN
-#define GYRO_1_EXTI_PIN                 ICM42688P_EXTI_PIN
-#define GYRO_1_ALIGN                    ICM42688P_ALIGN
+// SPA06-003 baro over I3C1 (PC10=SCL/PC11=SDA, AF4). First-cut probe; the
+// real driver is still to land. Probe reads CHIP_ID and parks the result for
+// SWD inspection.
+#define ENABLE_BARO_SPA06_PROBE         1
 
 // --- External flash: W25Q128JV on SPI1 -----------------------------------
 // AF5 standard for SPI1 on STM32C5.
@@ -133,11 +136,14 @@
 #define USE_LED_STRIP
 #define LED_STRIP_PIN                   PA8
 
+// PC6-PC9 motors on TIM8: C562 omits TIM3 from the C5 timer table, so the only
+// occurrence of these pins is TIM8 (index 1). C591/C5A3 has both TIM3 and TIM8
+// in the table -- those configs need index 2 for TIM8.
 #define TIMER_PIN_MAPPING \
-    TIMER_PIN_MAP(0, PC6, 2, -1) \
-    TIMER_PIN_MAP(1, PC7, 2, -1) \
-    TIMER_PIN_MAP(2, PC8, 2, -1) \
-    TIMER_PIN_MAP(3, PC9, 2, -1) \
+    TIMER_PIN_MAP(0, PC6, 1, -1) \
+    TIMER_PIN_MAP(1, PC7, 1, -1) \
+    TIMER_PIN_MAP(2, PC8, 1, -1) \
+    TIMER_PIN_MAP(3, PC9, 1, -1) \
     TIMER_PIN_MAP(4, PA8, 1, -1)
 
 #define DEFAULT_PID_PROCESS_DENOM       2

--- a/configs/ARCROBO_C562V1/config.h
+++ b/configs/ARCROBO_C562V1/config.h
@@ -149,10 +149,23 @@
 #define DEFAULT_PID_PROCESS_DENOM       2
 
 // --- ADC: VBAT + current + RSSI ------------------------------------------
+// PC1/PC2/PC3 are ADC1/ADC2 channels 11/12/13 per the C5 ADC pin table.
+// ADC1_DMA_OPT picks the first DMA spec entry (LPDMA2 ch 0) for ADC1; default
+// DMA_OPT_UNUSED (-1) makes dmaGetChannelSpecByPeripheral return NULL and the
+// per-device init loop bails out silently, leaving adcValues[] at zero.
+// DEFAULT_*_METER_SOURCE = ADC is required because config.c:applyConfig() overrides
+// adcConfig.vbat.enabled / .current.enabled to (source == ADC); without these defaults
+// the external channels stay disabled and only the internal VREFINT / TEMPSENSOR sample.
+#define USE_ADC
+#define USE_ADC_INTERNAL
+#define ADC_INSTANCE                    ADC1
+#define ADC1_DMA_OPT                    0
 #define ADC_VBAT_PIN                    PC1
 #define ADC_CURR_PIN                    PC2
 #define ADC_RSSI_PIN                    PC3
 #define ADC1_INSTANCE                   ADC1
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_ADC
 
 // --- Buzzer --------------------------------------------------------------
 // Passive buzzer driven by PC5 via Q1 MOSFET (inverted).

--- a/configs/NUCLEOC562/config.h
+++ b/configs/NUCLEOC562/config.h
@@ -111,11 +111,6 @@
     TIMER_PIN_MAP( 2, PB10, 1, -1) \
     TIMER_PIN_MAP( 3, PB11, 1, -1)
 
-// 4 kHz PID loop at the default 8 kHz gyro rate (denom = gyro / pid).
-// Keeps headroom for the C562 / 144 MHz core during bring-up; can be
-// raised once the platform settles.
-#define DEFAULT_PID_PROCESS_DENOM 2
-
 // ADC1 routes via LPDMA2 CH0 on the C5. The dmaChannelSpec opts 0-7
 // are LPDMA1 CH0-7 (used by DSHOT bitbang pacers and SPI), so pick
 // opt 8 (LPDMA2 CH0) which is free for the ADC. Default of


### PR DESCRIPTION
Adds the ARCROBO_C562V1 flight controller (STM32C562RET6): LSM6DSK320X IMU on SPI3, SPA06-003 baro over I3C-as-I2C, AT7456E OSD on SPI2, W25Q128 flash on SPI1, ADC for VBAT/current/RSSI, DShot bitbang on TIM8.

Depends on the STM32C562 platform support in betaflight/betaflight (SPI over LPDMA, I3C-as-I2C legacy reads, ADC internal-sensor guard).

Also drops a now-redundant `DEFAULT_PID_PROCESS_DENOM` from NUCLEOC562 — the C5 target defaults it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full support for the ARCROBO_C562V1 flight controller board with complete hardware configuration.

* **Chores**
  * Updated board configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->