### PR TITLE
Add CUSTS3AIO

### DIFF
--- a/configs/CUSTS3AIO/config.h
+++ b/configs/CUSTS3AIO/config.h
@@ -86,11 +86,12 @@
 
 // --- Motors ----------------------------------------------------------------
 // MCT8329A drivers take a PWM throttle on their SPEED input, so default to
-// standard PWM (DShot stays selectable). M5 (PA6) / M6 (PA35) are unused.
-#define MOTOR1_PIN           PA4    // M1
-#define MOTOR2_PIN           PA33   // M2
-#define MOTOR3_PIN           PA5    // M3
-#define MOTOR4_PIN           PA34   // M4
+// standard PWM (DShot stays selectable). Betaflight quad-X motor order:
+//   M1 back-right=GPIO33, M2 front-right=GPIO35, M3 back-left=GPIO4, M4 front-left=GPIO6.
+#define MOTOR1_PIN           PA33   // M1 (back right)
+#define MOTOR2_PIN           PA35   // M2 (front right)
+#define MOTOR3_PIN           PA4    // M3 (back left)
+#define MOTOR4_PIN           PA6    // M4 (front left)
 
 // --- LED strip -------------------------------------------------------------
 // Single WS2812 used as a status indicator (green disarmed / blue armed,

--- a/configs/CUSTS3AIO/config.h
+++ b/configs/CUSTS3AIO/config.h
@@ -53,11 +53,12 @@
 // --- Gyro/Acc on SPI0 ------------------------------------------------------
 // ICM-42688-P. INT1 is not wired to the MCU on this board, so GYRO_1_EXTI_PIN
 // is intentionally omitted: the gyro runs in the polled (GYRO_EXTI_NO_INT)
-// path. ALIGN is a placeholder - verify against the physical IMU mounting.
+// path. ALIGN is CW180: the IMU is mounted rotated 180 deg in yaw, matching the
+// reference firmware's -X/-Y/+Z gyro/acc axis handling (FlightControllerY3).
 #define USE_SPI_GYRO
 #define GYRO_1_SPI_INSTANCE  SPI0
 #define GYRO_1_CS_PIN        PA39   // MPUCS
-#define GYRO_1_ALIGN         CW0_DEG
+#define GYRO_1_ALIGN         CW180_DEG
 
 #define SPI0_SCK_PIN         PA38   // CLK
 #define SPI0_SDI_PIN         PA36   // MISO

--- a/configs/CUSTS3AIO/config.h
+++ b/configs/CUSTS3AIO/config.h
@@ -85,8 +85,12 @@
 #define UART1_RX_PIN         PA16   // RX
 
 // --- Motors ----------------------------------------------------------------
-// MCT8329A drivers take a PWM throttle on their SPEED input, so default to
-// standard PWM (DShot stays selectable). Betaflight quad-X motor order:
+// The MCT8329A6 BLDC drivers read the DUTY CYCLE of a PWM throttle on their SPEED
+// input (0% = stop, ~100% = full), so they are driven with duty-cycle PWM at 1 kHz
+// (Betaflight's BRUSHED protocol), exactly as the reference firmware does - NOT the
+// 1-2 ms RC PWM, which would idle at ~50% duty. The chips' speed-input mode is set
+// in their own EEPROM, so no I2C configuration is needed at boot.
+// Betaflight quad-X motor order (schematic M1/M2/M5/M6):
 //   M1 back-right=GPIO33, M2 front-right=GPIO35, M3 back-left=GPIO4, M4 front-left=GPIO6.
 #define MOTOR1_PIN           PA33   // M1 (back right)
 #define MOTOR2_PIN           PA35   // M2 (front right)
@@ -102,7 +106,8 @@
 #define LED_STRIP_DEFAULT_LED0  DEFINE_LED(0, 0, 0, 0, LED_FUNCTION_ARM_STATE, LED_FLAG_OVERLAY(LED_OVERLAY_WARNING))
 
 // --- Defaults --------------------------------------------------------------
-#define DEFAULT_MOTOR_PROTOCOL          MOTOR_PROTOCOL_PWM
+#define DEFAULT_MOTOR_PROTOCOL          MOTOR_PROTOCOL_BRUSHED
+#define DEFAULT_MOTOR_PWM_RATE          1000   // Hz; MCT8329A6 SPEED duty-cycle PWM, per the Y3
 #define DEFAULT_FEATURES                (FEATURE_LED_STRIP)
 #define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
 #define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_VIRTUAL

--- a/configs/CUSTS3AIO/config.h
+++ b/configs/CUSTS3AIO/config.h
@@ -106,14 +106,26 @@
 #define LED_STRIP_DEFAULT_LED0  DEFINE_LED(0, 0, 0, 0, LED_FUNCTION_ARM_STATE, LED_FLAG_OVERLAY(LED_OVERLAY_WARNING))
 
 // --- Defaults --------------------------------------------------------------
+// Advertise BRUSHED in the MSP build-options list (msp_build_info.c gates
+// BUILD_OPTION_BRUSHED on USE_BRUSHED) so the Configurator offers it rather than
+// greying it out. The protocol itself is enum-driven; USE_BRUSHED_MOTORS only sets
+// the pgReset default and is not needed here (DEFAULT_MOTOR_PROTOCOL handles that).
+#define USE_BRUSHED
 #define DEFAULT_MOTOR_PROTOCOL          MOTOR_PROTOCOL_BRUSHED
 #define DEFAULT_MOTOR_PWM_RATE          1000   // Hz; MCT8329A6 SPEED duty-cycle PWM, per the Y3
 #define DEFAULT_FEATURES                (FEATURE_LED_STRIP)
+// Serial RX enabled by default on UART1 (the FPC serial-RX port), provider CRSF -
+// the protocol ELRS and TBS Crossfire receivers speak. Set explicitly rather than
+// leaning on the implicit default; change serialrx_provider for SBUS/other receivers.
+#define DEFAULT_RX_FEATURE              FEATURE_RX_SERIAL
+#define SERIALRX_UART                   SERIAL_PORT_UART1
+#define SERIALRX_PROVIDER               SERIALRX_CRSF
 #define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
 #define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_VIRTUAL
 #define DEFAULT_VOLTAGE_METER_SCALE     60
 #define DEFAULT_BLACKBOX_DEVICE         BLACKBOX_DEVICE_SERIAL
 
-// Polled gyro on a port with a high per-iteration cost: decimate the PID loop
-// to keep the scheduler within budget. Tune once real loop timing is known.
-#define DEFAULT_PID_PROCESS_DENOM       4
+// Polled gyro plus an expensive ESP32 PID/control task (~470 us measured on the
+// dev board): a 2 kHz loop (denom 4) overruns the scheduler. Denom 8 runs PID at
+// 1 kHz (gyro 8 kHz) with the scheduler in budget.
+#define DEFAULT_PID_PROCESS_DENOM       8

--- a/configs/CUSTS3AIO/config.h
+++ b/configs/CUSTS3AIO/config.h
@@ -1,0 +1,113 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// ---------------------------------------------------------------------------
+// CUSTS3AIO - custom ESP32-S3 all-in-one flight controller.
+//
+//   MCU    : ESP32-S3-MINI-1-N4R2 (4 MB flash, 2 MB PSRAM unused), native USB.
+//   IMU    : InvenSense ICM-42688-P on SPI0 (FSPI). INT not routed -> polled.
+//   Baro   : Bosch BMP580 on I2C0.
+//   ESCs   : 6x TI MCT8329A integrated BLDC drivers (PWM "SPEED" input);
+//            4 used as a quad (M1-M4).
+//   LED    : single WS2812 status LED.
+//   USB-C  : native ESP32-S3 USB (GPIO19/20).
+//   Also fitted but UNUSED by Betaflight: ST VL53L1 ToF on I2C0 (no BF driver).
+//
+// Pin map derived from the board schematic; GPIOn == PAn in Betaflight tags.
+// ---------------------------------------------------------------------------
+
+#define FC_TARGET_MCU     ESP32S3
+
+#define BOARD_NAME        CUSTS3AIO
+#define MANUFACTURER_ID   CUST
+
+// --- Sensors ---------------------------------------------------------------
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACC_SPI_ICM42688P
+#define USE_GYRO_SPI_ICM42688P
+
+#define USE_BARO
+#define USE_BARO_BMP580
+
+// --- Gyro/Acc on SPI0 ------------------------------------------------------
+// ICM-42688-P. INT1 is not wired to the MCU on this board, so GYRO_1_EXTI_PIN
+// is intentionally omitted: the gyro runs in the polled (GYRO_EXTI_NO_INT)
+// path. ALIGN is a placeholder - verify against the physical IMU mounting.
+#define USE_SPI_GYRO
+#define GYRO_1_SPI_INSTANCE  SPI0
+#define GYRO_1_CS_PIN        PA39   // MPUCS
+#define GYRO_1_ALIGN         CW0_DEG
+
+#define SPI0_SCK_PIN         PA38   // CLK
+#define SPI0_SDI_PIN         PA36   // MISO
+#define SPI0_SDO_PIN         PA37   // MOSI
+
+// --- I2C0 (barometer) ------------------------------------------------------
+#define BARO_I2C_INSTANCE    I2CDEV_0
+#define I2C0_SCL_PIN         PA42   // VLCLK
+#define I2C0_SDA_PIN         PA41   // VLDA
+
+// --- ADC -------------------------------------------------------------------
+// Battery voltage on GPIO1 (ADC1_CH0) via a 50k/10k divider (VBAT/6).
+// VOLTAGE_METER_SCALE below is a first estimate - calibrate on the bench, the
+// ESP32-S3 ADC uses an eFuse-trimmed Vref so the exact scale is board/part
+// dependent. No shunt is fitted, hence the virtual current meter.
+#define USE_ADC
+#define ADC_VBAT_PIN         PA1    // VSENSE
+
+// --- UARTs -----------------------------------------------------------------
+// UART0: native console pins (U0TXD/U0RXD), not broken out for the user.
+// UART1: TX/RX broken out on the FPC connector - primary serial-RX port.
+#define UART0_TX_PIN         PA43
+#define UART0_RX_PIN         PA44
+#define UART1_TX_PIN         PA15   // TX
+#define UART1_RX_PIN         PA16   // RX
+
+// --- Motors ----------------------------------------------------------------
+// MCT8329A drivers take a PWM throttle on their SPEED input, so default to
+// standard PWM (DShot stays selectable). M5 (PA6) / M6 (PA35) are unused.
+#define MOTOR1_PIN           PA4    // M1
+#define MOTOR2_PIN           PA33   // M2
+#define MOTOR3_PIN           PA5    // M3
+#define MOTOR4_PIN           PA34   // M4
+
+// --- LED strip -------------------------------------------------------------
+// Single WS2812 used as a status indicator (green disarmed / blue armed,
+// blinking on warnings) so it is driven out of reset rather than sitting at
+// its uncontrolled bright-white power-on state.
+#define LED_STRIP_PIN        PA8    // LED
+#define LED_STRIP_DEFAULT_BRIGHTNESS 20
+#define LED_STRIP_DEFAULT_LED0  DEFINE_LED(0, 0, 0, 0, LED_FUNCTION_ARM_STATE, LED_FLAG_OVERLAY(LED_OVERLAY_WARNING))
+
+// --- Defaults --------------------------------------------------------------
+#define DEFAULT_MOTOR_PROTOCOL          MOTOR_PROTOCOL_PWM
+#define DEFAULT_FEATURES                (FEATURE_LED_STRIP)
+#define DEFAULT_VOLTAGE_METER_SOURCE    VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE    CURRENT_METER_VIRTUAL
+#define DEFAULT_VOLTAGE_METER_SCALE     60
+#define DEFAULT_BLACKBOX_DEVICE         BLACKBOX_DEVICE_SERIAL
+
+// Polled gyro on a port with a high per-iteration cost: decimate the PID loop
+// to keep the scheduler within budget. Tune once real loop timing is known.
+#define DEFAULT_PID_PROCESS_DENOM       4

--- a/configs/CUSTS3AIO/config.mk
+++ b/configs/CUSTS3AIO/config.mk
@@ -1,0 +1,5 @@
+# CUSTS3AIO uses an ESP32-S3-MINI-1-N4R2 module: 4 MB flash (2 MB PSRAM unused).
+# Override the 8 MB ESP32S3 default so the app image, the merged full image and
+# the from-source bootloader header are all built for 4 MB. Included before
+# target.mk / ESP32S3.mk (see mk/config.mk), which set MCU_FLASH_SIZE with ?=.
+MCU_FLASH_SIZE := 4096

--- a/configs/LONELYBINARY/config.h
+++ b/configs/LONELYBINARY/config.h
@@ -1,0 +1,79 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+// ---------------------------------------------------------------------------
+// LONELYBINARY - ESP32-S3 bring-up / development board ("the lonely binary").
+//
+//   MCU   : ESP32-S3 (16 MB flash, 8 MB PSRAM unused), native USB VCP.
+//   IMU   : InvenSense MPU-6500 on SPI0 (the MPU-9250 driver also detects it),
+//           INT1 wired to GPIO9 (data-ready EXTI).
+//   LED   : WS2812 NeoPixel on GPIO48.
+//   Motors: 4x PWM (LEDC) on GPIO4-7, kept clear of the JTAG pins (GPIO39-42).
+//
+// This is the board the ESP32-S3 port was brought up on; the pin map mirrors
+// the defaults that used to live directly in the ESP32S3 target.h (now config
+// driven). GPIOn == PAn in Betaflight pin tags.
+// ---------------------------------------------------------------------------
+
+#define FC_TARGET_MCU     ESP32S3
+
+#define BOARD_NAME        LONELYBINARY
+#define MANUFACTURER_ID   CUST
+
+// --- Sensors ---------------------------------------------------------------
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACC_SPI_MPU6500
+#define USE_GYRO_SPI_MPU6500
+#define USE_ACC_SPI_MPU9250
+#define USE_GYRO_SPI_MPU9250
+
+// --- Gyro/Acc on SPI0 ------------------------------------------------------
+#define USE_SPI_GYRO
+#define GYRO_1_SPI_INSTANCE  SPI0
+#define GYRO_1_CS_PIN        PA10
+#define GYRO_1_EXTI_PIN      PA9
+#define GYRO_1_ALIGN         CW0_DEG
+
+#define SPI0_SCK_PIN         PA12
+#define SPI0_SDI_PIN         PA13   // MISO
+#define SPI0_SDO_PIN         PA11   // MOSI
+
+// --- Motors ----------------------------------------------------------------
+#define MOTOR1_PIN           PA4
+#define MOTOR2_PIN           PA5
+#define MOTOR3_PIN           PA6
+#define MOTOR4_PIN           PA7
+
+// --- LED strip -------------------------------------------------------------
+// Single WS2812 NeoPixel used as a status indicator, driven out of reset.
+#define LED_STRIP_PIN        PA48
+#define LED_STRIP_DEFAULT_BRIGHTNESS 20
+#define LED_STRIP_DEFAULT_LED0  DEFINE_LED(0, 0, 0, 0, LED_FUNCTION_ARM_STATE, LED_FLAG_OVERLAY(LED_OVERLAY_WARNING))
+
+// --- Defaults --------------------------------------------------------------
+#define DEFAULT_MOTOR_PROTOCOL          MOTOR_PROTOCOL_PWM
+#define DEFAULT_FEATURES                (FEATURE_LED_STRIP)
+
+// High per-iteration cost on this port; decimate the PID loop. Tune to taste.
+#define DEFAULT_PID_PROCESS_DENOM       4

--- a/configs/LONELYBINARY/config.h
+++ b/configs/LONELYBINARY/config.h
@@ -59,6 +59,13 @@
 #define SPI0_SDI_PIN         PA13   // MISO
 #define SPI0_SDO_PIN         PA11   // MOSI
 
+// --- UARTs -----------------------------------------------------------------
+// UART0 is the native console (not broken out). UART1 is brought out for the
+// serial-RX bench test on two free GPIOs (any GPIO works via the ESP32 matrix);
+// PA15/PA16 mirror CUSTS3AIO's UART1.
+#define UART1_RX_PIN         PA16   // RX  (wire CRSF source TX here)
+#define UART1_TX_PIN         PA15   // TX  (CRSF telemetry back)
+
 // --- Motors ----------------------------------------------------------------
 #define MOTOR1_PIN           PA4
 #define MOTOR2_PIN           PA5
@@ -75,5 +82,12 @@
 #define DEFAULT_MOTOR_PROTOCOL          MOTOR_PROTOCOL_PWM
 #define DEFAULT_FEATURES                (FEATURE_LED_STRIP)
 
-// High per-iteration cost on this port; decimate the PID loop. Tune to taste.
-#define DEFAULT_PID_PROCESS_DENOM       4
+// Serial RX on UART1, provider CRSF (ELRS/Crossfire) - for the CRSF bench test.
+#define DEFAULT_RX_FEATURE              FEATURE_RX_SERIAL
+#define SERIALRX_UART                   SERIAL_PORT_UART1
+#define SERIALRX_PROVIDER               SERIALRX_CRSF
+
+// The ESP32 PID/control task is ~470 us, so a 2 kHz loop (denom 4) overruns the
+// scheduler (tasks run late -> LOAD). Denom 8 runs PID at 1 kHz with the gyro still
+// at 8 kHz, ~36% CPU and the scheduler in budget. Measured on this board.
+#define DEFAULT_PID_PROCESS_DENOM       8

--- a/configs/LONELYBINARY/config.mk
+++ b/configs/LONELYBINARY/config.mk
@@ -1,0 +1,4 @@
+# The "lonely binary" dev board carries a 16 MB flash module (confirmed by
+# esptool flash_id). Override the 8 MB ESP32S3 default; target.mk / ESP32S3.mk
+# use ?= so this config.mk value (included first) wins. See mk/config.mk.
+MCU_FLASH_SIZE := 16384


### PR DESCRIPTION
Adds a config for CUSTS3AIO — a custom ESP32-S3 (S3-MINI-1-N4R2, 4 MB flash) all-in-one.

- ICM-42688-P gyro/acc on SPI
- BMP580 barometer on I2C
- Six integrated MCT8329A ESCs, four driven as a quad
- WS2812 status LED, native USB VCP, battery voltage sense

Needs the ESP32-S3 platform support in betaflight/betaflight#15338 (board-config plumbing and per-board flash size).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **CUSTS3AIO** ESP32-S3 target with configured IMU (SPI gyro/accelerometer), BMP580 barometer, VBAT sensing, motor PWM outputs, and a WS2812 status LED strip.
  * Added support for the **LONELYBINARY** ESP32-S3 bring-up target with IMU SPI options (MPU6500/MPU9250), motor PWM outputs, and a WS2812 status LED strip.
* **Build/Configuration**
  * Updated target build settings to use the correct flash size per board (**4MB** for CUSTS3AIO, **16MB** for LONELYBINARY).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->