### PR TITLE
Remove unused checkout from auto-close workflow

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -14,9 +14,6 @@ jobs:
     if: github.repository == 'betaflight/config'
     runs-on: ubuntu-latest
     steps:
-      - name: Code Checkout
-        uses: actions/checkout@v5
-
       - name: autoclose
         shell: bash
         if: github.head_ref == 'master'


### PR DESCRIPTION
Drops an unused actions/checkout from auto-close.yml. The job only runs gh pr close, which needs no checkout.
