### PR TITLE
MATEKH743: default the CAN pins

### DIFF
--- a/configs/MATEKH743/config.h
+++ b/configs/MATEKH743/config.h
@@ -101,6 +101,9 @@
 #define SDIO_D3_PIN          PC11
 #define PINIO1_PIN           PD10
 #define PINIO2_PIN           PD11
+#define CAN1_TX_PIN          PD1
+#define CAN1_RX_PIN          PD0
+#define CAN1_SILENT_PIN      PD3
 #define MAX7456_SPI_CS_PIN   PB12
 #define GYRO_1_EXTI_PIN      PB2
 #define GYRO_2_EXTI_PIN      PE15


### PR DESCRIPTION
The whole Matek H743 family routes CAN1 to PD0/PD1 with the transceiver's silent/standby input on PD3 (per the vendor pinout and ArduPilot's family hwdef), so default all three. TX/RX defaults work with current firmware; `CAN1_SILENT_PIN` is picked up once betaflight/betaflight#15429 lands and is inert before that. Verified on a Matek H743 WLITE with a DroneCAN compass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CAN1 pin configuration for transmission, reception, and silent-mode control on the MATEKH743 board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->