### PR TITLE
Fix AXISFLYINGH7AIO UART4/UART5

### DIFF
--- a/configs/AXISFLYINGH7AIO/config.h
+++ b/configs/AXISFLYINGH7AIO/config.h
@@ -48,7 +48,6 @@
 #define UART1_TX_PIN         PA9
 #define UART2_TX_PIN         PD5
 #define UART3_TX_PIN         PD8
-#define UART5_TX_PIN         PC12
 #define UART6_TX_PIN         PC6
 #define UART7_TX_PIN         PE8
 #define UART8_TX_PIN         PE1
@@ -56,7 +55,7 @@
 #define UART1_RX_PIN         PA10
 #define UART2_RX_PIN         PD6
 #define UART3_RX_PIN         PD9
-#define UART5_RX_PIN         PC11
+#define UART4_RX_PIN         PC11
 #define UART6_RX_PIN         PC7
 #define UART7_RX_PIN         PE7
 #define UART8_RX_PIN         PE0
@@ -109,7 +108,7 @@
 #ifdef USE_GPS
 #define GPS_UART                       SERIAL_PORT_USART3
 #endif
-#define ESC_SENSOR_UART                SERIAL_PORT_UART5
+#define ESC_SENSOR_UART                SERIAL_PORT_UART4
 
 #define DEFAULT_BLACKBOX_DEVICE        BLACKBOX_DEVICE_FLASH
 #define DEFAULT_DSHOT_BITBANG          DSHOT_BITBANG_ON


### PR DESCRIPTION
In the schematic, the 'RX5' net, connected to PC11, is used for ESC telemetry from the AIO ESCs. The 'TX5' net is not used anywhere. However, PC11 only has USART3_RX or UART4_RX as alternate function, not UART5_RX. So let's change it to UART4 to fix this.
    
(Note that ESC telemetry is currently not working on this FC, as AM32 has removed serial telemetry output from the PA14 GPIO on non-F421 MCUs due to the dual role as GPIO and SWCLK this pin has. This might change in the future, but with current stock AM32 FW, ESC telemetry does not work. (For more info see https://github.com/am32-firmware/AM32/pull/373.) I have confirmed ESC telemetry working using UART4 on PC11 with a custom AM32 build implementing the aforementioned PR.)