### PR TITLE
Add ARCROBO Pte., Ltd to Manufacturers list

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -9,7 +9,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FOSS|Free open source target definitions||
 |COMM|Community provided target definitions for closed source targets||
 |LEGA|Closed source legacy targets without a maintainer||
-|ACRO|ARCROBO Pte., Ltd|www.arcrobo.com.sg|
+|ACRO|ARCROBO Pte., Ltd|https://www.arcrobo.com.sg/|
 |AEDR|AEDROX|https://www.aedrox.com/|
 |AERO|AeroCogito|https://www.aerocogito.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -9,6 +9,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FOSS|Free open source target definitions||
 |COMM|Community provided target definitions for closed source targets||
 |LEGA|Closed source legacy targets without a maintainer||
+|ACRO|ARCROBO Pte., Ltd|www.arcrobo.com.sg|
 |AEDR|AEDROX|https://www.aedrox.com/|
 |AERO|AeroCogito|https://www.aerocogito.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|
@@ -18,7 +19,6 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |ALWH|Alienwhoop|https://shop.alienwhoop.us/|
 |ANYL|AnyLeaf|https://www.anyleaf.org/|
 |APEX|Apexfpv|https://apexfpv.eu/|
-|ARCR|ARCROBO Pte., Ltd|www.arcrobo.com.sg|
 |ARKE|ARK Electronics|https://arkelectron.com/|
 |ASKY|AcroSky||
 |AXFL|Axisflying|https://www.axisflying.com/|

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -9,7 +9,6 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FOSS|Free open source target definitions||
 |COMM|Community provided target definitions for closed source targets||
 |LEGA|Closed source legacy targets without a maintainer||
-|ACRO|ACROBO Pte., Ltd|www.arcrobo.com.sg|
 |AEDR|AEDROX|https://www.aedrox.com/|
 |AERO|AeroCogito|https://www.aerocogito.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|
@@ -19,6 +18,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |ALWH|Alienwhoop|https://shop.alienwhoop.us/|
 |ANYL|AnyLeaf|https://www.anyleaf.org/|
 |APEX|Apexfpv|https://apexfpv.eu/|
+|ARCR|ARCROBO Pte., Ltd|www.arcrobo.com.sg|
 |ARKE|ARK Electronics|https://arkelectron.com/|
 |ASKY|AcroSky||
 |AXFL|Axisflying|https://www.axisflying.com/|

--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -9,6 +9,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |FOSS|Free open source target definitions||
 |COMM|Community provided target definitions for closed source targets||
 |LEGA|Closed source legacy targets without a maintainer||
+|ACRO|ACROBO Pte., Ltd|www.arcrobo.com.sg|
 |AEDR|AEDROX|https://www.aedrox.com/|
 |AERO|AeroCogito|https://www.aerocogito.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|


### PR DESCRIPTION

# **A**r**CRO**bo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the **ARCROBO Pte., Ltd** manufacturer entry (ID: **ACRO**) to the Manufacturers list, including a direct contact link, making it available for selection in the Betaflight Configurator.

* **Documentation**
  * Updated `Manufacturers.md` to include this new manufacturer row; no other manufacturer entries were modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->