### PR TITLE
Remove Pin IO user configurable USE flags

### DIFF
--- a/configs/SPRO/SPRACINGH7EF/config.h
+++ b/configs/SPRO/SPRACINGH7EF/config.h
@@ -184,7 +184,9 @@
 #define ADC_EXTERNAL1_PIN    CURRENT_METER_2_ADC_PIN
 
 #define VTX_ENABLE_PIN                PB11
+#define USE_PINIO
 #define PINIO1_PIN                    VTX_ENABLE_PIN
+#define USE_PINIOBOX
 
 #define USE_ACC
 #define USE_ACC_SPI_ICM42605

--- a/configs/SPRO/SPRACINGH7EF/config.h
+++ b/configs/SPRO/SPRACINGH7EF/config.h
@@ -184,9 +184,7 @@
 #define ADC_EXTERNAL1_PIN    CURRENT_METER_2_ADC_PIN
 
 #define VTX_ENABLE_PIN                PB11
-#define USE_PINIO
 #define PINIO1_PIN                    VTX_ENABLE_PIN
-#define USE_PINIOBOX
 
 #define USE_ACC
 #define USE_ACC_SPI_ICM42605

--- a/configs/TEBS/TBS_LUCID_RPI_FC/config.h
+++ b/configs/TEBS/TBS_LUCID_RPI_FC/config.h
@@ -149,8 +149,6 @@ DATE: 2026-05-01
 
 // VTX BEC enable -- single 10 V rail, transistor-driven (Q3) on PA18
 // Exposed as PINIO1 so the user can toggle the rail from the GUI/CLI
-#define USE_PINIO
-#define USE_PINIOBOX
 #define VTX_ENABLE_PIN       PA18
 #define PINIO1_PIN           VTX_ENABLE_PIN
 #define PINIO1_BOX           40


### PR DESCRIPTION
The `USE_PINIO` is a user configurable setting in the flasher and `USE_PINIOBOX` is enabled automatically if `USE_PINIO` is defined. Having `USE_PINIO` in the target `config.h` leads to build errors if the user enables "Pin IO" in the flasher, thus they need to be removed.

Technically we could also gate the `USE_PINIO` flag behind a `ifndef` to force it for specific boards, but we've never done that before. Adding `USE_PINIOBOX` is superfluous, so can be removed safely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated flight-controller configurations to remove obsolete pin-control options.
  * Preserved video-transmitter enable-pin functionality for supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->