### PR TITLE
DEEPSPACEH7AIO: remove unused definitions

### DIFF
--- a/configs/DPDS/DEEPSPACEH7AIO/config.h
+++ b/configs/DPDS/DEEPSPACEH7AIO/config.h
@@ -89,10 +89,6 @@
 #define SPI3_SDI_PIN          PC11
 #define SPI3_SDO_PIN          PC12
 
-#define SPI4_SCK_PIN          PE12
-#define SPI4_SDI_PIN          PE13
-#define SPI4_SDO_PIN          PE14
-
 #define CAMERA_CONTROL_PIN    PB14
 
 #define ADC_VBAT_PIN          PC0
@@ -101,7 +97,6 @@
 #define LED0_PIN              PE3
 
 #define PINIO1_PIN            PD10
-#define PINIO2_PIN            PD11
 
 #define GYRO_1_CS_PIN         PC15
 #define GYRO_1_EXTI_PIN       PB2
@@ -157,7 +152,6 @@
 #define FLASH_SPI_INSTANCE              SPI3
 
 #define PINIO1_BOX                      40
-#define PINIO2_BOX                      41
 
 #define PINIO1_CONFIG                   129
 #define BOX_USER1_NAME                  "10V BEC"


### PR DESCRIPTION
In the schematic, some functions were present in multiple occasions, but are not actually routed to pads or used in general. Let's remove them from the target file.

@coderabbitai In the original PR where this target was added, you might have wanted to flag the definitions of SPI4 pins, where no SPI4 bus was actually used elsewhere in the `config.h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused hardware configuration entries for the DEEPSPACEH7AIO target.
  * Simplified target configuration by eliminating unsupported SPI4 and PINIO2 settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->