### PR TITLE
Add Agam Robotics to Manufacturers list

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -13,6 +13,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |AEDR|AEDROX|https://www.aedrox.com/|
 |AERO|AeroCogito|https://www.aerocogito.com/|
 |AFNG|AlienFlight NG|https://www.alienflightng.com/|
+|AGAM|Agam Robotics|https://www.agamrobotics.com/shop/|
 |AIKO|AIKON Electronics|https://www.aikon-electronics.com/|
 |AIRB|Airbot|https://store.myairbot.com/|
 |AKIN|AKINGFPV|https://www.akingfpv.com/|


### PR DESCRIPTION
Registers the manufacturer id `AGAM` for Agam Robotics.

Requesting registration ahead of submitting our first target, as required by [Requirements for the Submission of New and Updated Targets](https://betaflight.com/docs/development/manufacturer/requirements-for-submission-of-targets) — the manufacturer id is also the config directory name, so it needs to exist before the first `configs/AGAM/<BOARD_NAME>/config.h` is submitted.

|Field|Value|
|-|-|
|Manufacturer Id|AGAM|
|Name|Agam Robotics|
|Contact|https://www.agamrobotics.com/shop/|

`AGAM` is not currently in use, and the entry is inserted in alphabetical order between `AFNG` and `AIKO`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Agam Robotics to the manufacturer listings, including its website URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->