### PR TITLE
add target SequoiaRCF722

### DIFF
--- a/Manufacturers.md
+++ b/Manufacturers.md
@@ -119,6 +119,7 @@ This is the official list of manufacturer ids (`manufacturer_id` in the target c
 |RDMS|RadioMaster RC|https://www.radiomasterrc.com/|
 |RUSH|FPV Racing Rush|http://www.rushfpv.com/|
 |SDRC|Siangda Model Co., Ltd|https://www.sdmodel.com.tw/|
+|SEQU|Sequoia RC|http://hsairc.com|
 |SFLY|Macfos Ltd|https://robu.in|
 |SJET|Shenzhen Jiufang Electronic Technology Co., Ltd|https://www.jiufang-tech.com/|
 |SKST|Shenzhen SKYSTARS Tech Co., LIMITED|http://www.skystars-rc.com/index.html|

--- a/configs/SEQU/SequoiaRCF722/config.h
+++ b/configs/SEQU/SequoiaRCF722/config.h
@@ -1,0 +1,114 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#define FC_TARGET_MCU     STM32F722
+
+#define BOARD_NAME        SequoiaRCF722
+#define MANUFACTURER_ID   SEQU
+
+#define USE_GYRO
+#define USE_ACC
+#define USE_GYRO_SPI_ICM42688P
+#define USE_ACC_SPI_ICM42688P
+#define USE_ACCGYRO_LSM6DSK320X
+#define USE_BARO
+#define USE_BARO_BMP280
+#define USE_BARO_DPS310
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+#define USE_FLASH_W25N01G
+#define USE_MAX7456
+#define USE_GYRO_CLKIN
+
+#define BEEPER_PIN           PA8
+#define MOTOR1_PIN           PC6
+#define MOTOR2_PIN           PC7
+#define MOTOR3_PIN           PC8
+#define MOTOR4_PIN           PC9
+#define SERVO1_PIN           PB6
+#define SERVO2_PIN           PB7
+#define LED_STRIP_PIN        PB10
+#define RX_PPM_PIN           PA3
+#define UART1_TX_PIN         PA9
+#define UART2_TX_PIN         PA2
+#define UART4_TX_PIN         PA0
+#define UART5_TX_PIN         PC12
+#define UART1_RX_PIN         PA10
+#define UART2_RX_PIN         PA3
+#define UART3_RX_PIN         PB11
+#define UART4_RX_PIN         PA1
+#define UART5_RX_PIN         PD2
+#define I2C1_SCL_PIN         PB8
+#define I2C1_SDA_PIN         PB9
+#define LED0_PIN             PA15
+#define LED1_PIN             PC10
+#define SPI1_SCK_PIN         PA5
+#define SPI2_SCK_PIN         PB13
+#define SPI3_SCK_PIN         PB3
+#define SPI1_SDI_PIN         PA6
+#define SPI2_SDI_PIN         PB14
+#define SPI3_SDI_PIN         PB4
+#define SPI1_SDO_PIN         PA7
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SDO_PIN         PB5
+#define ADC_VBAT_PIN         PC2
+#define ADC_RSSI_PIN         PC0
+#define ADC_CURR_PIN         PC1
+#define PINIO1_PIN           PC13
+#define PINIO2_PIN           PC14
+#define FLASH_CS_PIN         PC11
+#define MAX7456_SPI_CS_PIN   PB12
+#define GYRO_1_EXTI_PIN      PC4
+#define GYRO_1_CS_PIN        PA4
+#define GYRO_1_CLKIN_PIN     PB0
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PC6 , 2,  1) \
+    TIMER_PIN_MAP( 1, PC7 , 2,  1) \
+    TIMER_PIN_MAP( 2, PC8 , 2,  1) \
+    TIMER_PIN_MAP( 3, PC9 , 2,  1) \
+    TIMER_PIN_MAP( 4, PB6 , 1,  -1) \
+    TIMER_PIN_MAP( 5, PB7 , 1,  -1) \
+    TIMER_PIN_MAP( 6, PB10 , 1,  0) \
+    TIMER_PIN_MAP( 7, PA3 , 2,  -1) \
+    TIMER_PIN_MAP( 8, PB0 , 2,  -1) 
+
+#define SPI3_TX_DMA_OPT     0
+#define ADC1_DMA_OPT        1
+ 
+#define MAG_I2C_INSTANCE (I2CDEV_1)
+#define BARO_I2C_INSTANCE (I2CDEV_1)
+#define DEFAULT_BLACKBOX_DEVICE     BLACKBOX_DEVICE_FLASH
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SCALE 110
+#define DEFAULT_CURRENT_METER_SCALE 490
+#define BEEPER_INVERTED
+#define PINIO1_CONFIG 129
+#define PINIO2_CONFIG 129
+#define PINIO1_BOX 40
+#define PINIO2_BOX 41
+#define MAX7456_SPI_INSTANCE SPI2
+#define FLASH_SPI_INSTANCE SPI3
+#define GYRO_1_SPI_INSTANCE SPI1
+#define GYRO_1_ALIGN CW0_DEG


### PR DESCRIPTION
## Target details

- Board name: SequoiaRCF722
- Manufacturer: Sequoia RC
- Manufacturer ID: SEQU
- Manufacturer website: http://hsairc.com
- MCU: STM32F722
- Gyro/accelerometer: ICM42688P or LSM6DSO/LSM6DSV320X
- Barometer: BMP280 or DPS310
- Onboard flash: W25Q128FV or W25N01G
- OSD: MAX7456
- Motor outputs: 4
- Servo outputs: 2
- UARTs: 5
- Other features: LED strip, two PINIO outputs, current/voltage sensing, and onboard blackbox flash

**Checklist** (✓/✕, or y/n)
- [x] passed Betaflight team's schematics review
- [ ] passed hardware samples testing
- [x] follows guidelines
- [x] follows connector standards
- [x] flight tested
- [x] comments/issues resolved