### PR TITLE
Add AGAM_MEGH7

### DIFF
--- a/configs/AGAM/AGAM_MEGH7/config.h
+++ b/configs/AGAM/AGAM_MEGH7/config.h
@@ -1,0 +1,161 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#define FC_TARGET_MCU        STM32H743
+
+#define BOARD_NAME           AGAM_MEGH7
+#define MANUFACTURER_ID      AGAM
+
+#define USE_ACC
+#define USE_GYRO
+#define USE_ACCGYRO_ICM45686
+#define USE_BARO
+#define USE_BARO_BMP388
+#define USE_BARO_DPS310
+#define USE_MAX7456
+#define USE_MAG
+#define USE_MAG_QMC5883L
+#define USE_MAG_IST8310
+#define USE_SDCARD
+#define USE_FLASH
+#define USE_FLASH_W25Q128FV
+
+#define BEEPER_PIN           PA15
+#define MOTOR1_PIN           PB0
+#define MOTOR2_PIN           PB1
+#define MOTOR3_PIN           PA0
+#define MOTOR4_PIN           PA1
+#define MOTOR5_PIN           PA2
+#define MOTOR6_PIN           PA3
+#define MOTOR7_PIN           PD14
+#define MOTOR8_PIN           PD15
+#define LED_STRIP_PIN        PA8
+
+#define UART1_TX_PIN         PA9
+#define UART1_RX_PIN         PA10
+#define UART2_TX_PIN         PD5
+#define UART2_RX_PIN         PD6
+#define UART3_TX_PIN         PD8
+#define UART3_RX_PIN         PD9
+#define UART4_TX_PIN         PB9
+#define UART4_RX_PIN         PB8
+#define UART6_TX_PIN         PC6
+#define UART6_RX_PIN         PC7
+#define UART7_TX_PIN         PE8
+#define UART7_RX_PIN         PE7
+#define UART8_TX_PIN         PE1
+#define UART8_RX_PIN         PE0
+
+#define I2C1_SCL_PIN         PB6
+#define I2C1_SDA_PIN         PB7
+#define I2C2_SCL_PIN         PB10
+#define I2C2_SDA_PIN         PB11
+#define I2C4_SCL_PIN         PD12
+#define I2C4_SDA_PIN         PD13
+
+#define LED0_PIN             PE4
+#define LED1_PIN             PE3
+
+#define SPI1_SCK_PIN         PA5
+#define SPI1_SDI_PIN         PA6
+#define SPI1_SDO_PIN         PD7
+#define SPI2_SCK_PIN         PB13
+#define SPI2_SDI_PIN         PB14
+#define SPI2_SDO_PIN         PB15
+#define SPI3_SCK_PIN         PB3
+#define SPI3_SDI_PIN         PB4
+#define SPI3_SDO_PIN         PB5
+#define SPI4_SCK_PIN         PE12
+#define SPI4_SDI_PIN         PE13
+#define SPI4_SDO_PIN         PE14
+
+#define ADC_VBAT_PIN         PC0
+#define ADC_CURR_PIN         PC1
+#define ADC_RSSI_PIN         PC5
+#define ADC_EXTERNAL1_PIN    PC4
+#define ADC_EXTERNAL2_PIN    PA4
+
+#define SDIO_CK_PIN          PC12
+#define SDIO_CMD_PIN         PD2
+#define SDIO_D0_PIN          PC8
+#define SDIO_D1_PIN          PC9
+#define SDIO_D2_PIN          PC10
+#define SDIO_D3_PIN          PC11
+
+#define PINIO1_PIN           PE5
+#define PINIO2_PIN           PE15
+#define PINIO3_PIN           PE6
+
+#define FLASH_CS_PIN         PE11
+#define MAX7456_SPI_CS_PIN   PD10
+#define GYRO_1_CS_PIN        PD11
+#define GYRO_1_EXTI_PIN      PB2
+
+#define TIMER_PIN_MAPPING \
+    TIMER_PIN_MAP( 0, PB0 , 2,  0) \
+    TIMER_PIN_MAP( 1, PB1 , 2,  1) \
+    TIMER_PIN_MAP( 2, PA0 , 2,  2) \
+    TIMER_PIN_MAP( 3, PA1 , 2,  3) \
+    TIMER_PIN_MAP( 4, PA2 , 2,  4) \
+    TIMER_PIN_MAP( 5, PA3 , 2,  5) \
+    TIMER_PIN_MAP( 6, PD14, 1,  6) \
+    TIMER_PIN_MAP( 7, PD15, 1,  7) \
+    TIMER_PIN_MAP( 8, PA8 , 1,  8) \
+    TIMER_PIN_MAP( 9, PA15, 1, -1)
+
+#define ADC1_DMA_OPT         9
+#define TIMUP1_DMA_OPT       10
+#define TIMUP3_DMA_OPT       11
+#define TIMUP4_DMA_OPT       12
+#define TIMUP5_DMA_OPT       13
+
+#define BARO_I2C_INSTANCE            I2CDEV_2
+#define MAG_I2C_INSTANCE             I2CDEV_1
+
+#define GYRO_1_SPI_INSTANCE          SPI2
+#define GYRO_1_ALIGN                 CW90_DEG
+#define MAX7456_SPI_INSTANCE         SPI3
+#define FLASH_SPI_INSTANCE           SPI1
+
+#define DEFAULT_RX_FEATURE           FEATURE_RX_SERIAL
+#define SERIALRX_UART                SERIAL_PORT_USART6
+#define ESC_SENSOR_UART              SERIAL_PORT_UART8
+#define MSP_DISPLAYPORT_UART         SERIAL_PORT_USART2
+
+#define DEFAULT_BLACKBOX_DEVICE      BLACKBOX_DEVICE_SDCARD
+#define DEFAULT_VOLTAGE_METER_SOURCE VOLTAGE_METER_ADC
+#define DEFAULT_CURRENT_METER_SOURCE CURRENT_METER_ADC
+#define DEFAULT_VOLTAGE_METER_SCALE  110
+#define DEFAULT_CURRENT_METER_SCALE  250
+
+#define BEEPER_INVERTED
+#define BEEPER_PWM_HZ                2500
+
+#define SDCARD_DETECT_PIN            NONE
+#define SDIO_DEVICE                  SDIODEV_1
+#define SDIO_USE_4BIT                1
+
+// PE5 gates the 10V VTX rail through an active-high high-side switch. 129 is
+// OUT_PP | OUT_INVERTED, which idles the pin HIGH so the rail is powered from
+// boot; the USER1 box then pulls it low to cut VTX power.
+#define PINIO1_CONFIG                129
+#define PINIO1_BOX                   40

--- a/configs/AGAM/AGAM_MEGH7/config.h
+++ b/configs/AGAM/AGAM_MEGH7/config.h
@@ -129,7 +129,7 @@
 #define MAG_I2C_INSTANCE             I2CDEV_1
 
 #define GYRO_1_SPI_INSTANCE          SPI2
-#define GYRO_1_ALIGN                 CW90_DEG
+#define GYRO_1_ALIGN                 CW90_DEG_FLIP
 #define MAX7456_SPI_INSTANCE         SPI3
 #define FLASH_SPI_INSTANCE           SPI1
 

--- a/configs/AGAM/AGAM_MEGH7/config.h
+++ b/configs/AGAM/AGAM_MEGH7/config.h
@@ -32,9 +32,6 @@
 #define USE_BARO_BMP388
 #define USE_BARO_DPS310
 #define USE_MAX7456
-#define USE_MAG
-#define USE_MAG_QMC5883L
-#define USE_MAG_IST8310
 #define USE_SDCARD
 #define USE_FLASH
 #define USE_FLASH_W25Q128FV


### PR DESCRIPTION
Adds a target for the Agam Robotics MegH7 flight controller.

**Depends on #1191**, which registers the `AGAM` manufacturer id. The id is also this target's directory name, so that PR should merge first.

## Board

|  |  |
|-|-|
|MCU|STM32H743|
|IMU|ICM45686 on SPI2|
|Baro|BMP388 / SPL06 on I2C2|
|OSD|AT7456E (MAX7456-compatible) on SPI3|
|Storage|microSD (SDIO), plus optional W25Q128 on SPI1|
|Outputs|8 motors + LED strip|

## Notes

**Storage is a single target rather than two variants.** The W25Q128 is not populated on every board, so the config declares both `USE_SDCARD` and `USE_FLASH_W25Q128FV`. `DEFAULT_BLACKBOX_DEVICE` is SDCARD since the slot is always present; where the chip is fitted, `set blackbox_device = SPIFLASH` selects it. On boards without it the driver simply does not detect it.

Builds clean against master.

**Checklist** (✓/✕, or y/n)
- [ ] passed Betaflight team's schematics review
- [ ] passed hardware samples testing
- [x] follows guidelines
- [ ] follows connector standards
- [x] flight tested
- [x] comments/issues resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the AGAM_MEGH7 STM32H743 flight controller board.
  * Enabled onboard accelerometer, gyroscope, and barometer support.
  * Added MAX7456, SD card, and flash storage support.
  * Added serial, I²C, SPI, SDIO, ADC, timer, and DMA interface support.
  * Added board-specific pin mappings, default peripheral settings, programmable outputs, and voltage/current calibration.

* **Configuration Changes**
  * Updated gyroscope orientation for improved board alignment.
  * Removed target-specific magnetometer configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->