### PR TITLE
Fix RASPBERRY_PI_UAVFC motor GPIO order

### DIFF
--- a/configs/RASP/RASPBERRY_PI_UAVFC/config.h
+++ b/configs/RASP/RASPBERRY_PI_UAVFC/config.h
@@ -44,19 +44,18 @@
 // uart0 via LED connector (J2)
 #define PICO_TRACE_UART_INSTANCE  0
 #define PICO_TRACE_TX_GPIO       2 // J2 (LED connector) 3 of 3
-#define PICO_TRACE_RX_GPIO       4 // not connected
 #else
 // uart1 via Radio "UART2" connector (J3)
 #define PICO_TRACE_UART_INSTANCE  1
 #define PICO_TRACE_TX_GPIO       42
-#define PICO_TRACE_RX_GPIO       4 // not connected
 #endif
 #endif
 
-#define MOTOR1_PIN           PA6
-#define MOTOR2_PIN           PA7
-#define MOTOR3_PIN           PA8
-#define MOTOR4_PIN           PA9
+// Note motor pin order is descending GPIO number
+#define MOTOR1_PIN           PA9
+#define MOTOR2_PIN           PA8
+#define MOTOR3_PIN           PA7
+#define MOTOR4_PIN           PA6
 
 #define LED0_PIN             PA0
 #define LED1_PIN             PA1


### PR DESCRIPTION
Fix RASPBERRY_PI_UAVFC motor GPIO order

Motors are numbered in descending GPIO order (PA9, PA8, PA7, PA6).
Also, remove dummy PICO_TRACE_RX_GPIO (no longer required).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected motor channel assignments to match the intended hardware pin order.
  * Removed an obsolete trace-input configuration that could cause incorrect hardware communication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->