### PR TITLE
Add LSM6DSV32X support to ARK_FPV

### DIFF
--- a/configs/ARKE/ARK_FPV/config.h
+++ b/configs/ARKE/ARK_FPV/config.h
@@ -112,10 +112,11 @@
 #define MAG_I2C_INSTANCE    I2CDEV_4
 #define MAG_ALIGN           CW180_DEG
 
-// IIM42653 on SPI1
+// IIM-42653 (hwrev 0) or LSM6DSV32X (hwrev 1) on SPI1
 #define USE_ACC
 #define USE_GYRO
 #define USE_ACCGYRO_IIM42653
+#define USE_ACCGYRO_LSM6DSV16X
 #define USE_SPI
 #define USE_SPI_DEVICE_1
 #define SPI1_SCK_PIN        PA5


### PR DESCRIPTION
## Pull-Request requirements

ARK FPV hardware revision 1 replaces the IIM-42653 with an LSM6DSV32X on the same SPI1 CS/EXTI pins. Enable `USE_ACCGYRO_LSM6DSV16X` alongside `USE_ACCGYRO_IIM42653` so runtime WHO_AM_I detection can pick either chip.

LSM6DSV32X shares WHO_AM_I `0x70` with LSM6DSV16X. Correct ±32 g / ±4000 dps programming is in a companion firmware PR:

https://github.com/betaflight/betaflight/pull/TBD

**Housekeeping**
- Pull-Request only from a custom branch, not `master`.
- Existing supported target update (IMU option), not a new flight controller.

**Checklist** (✓/✕, or y/n)
- [x] passed Betaflight team's schematics review
- [ ] passed hardware samples testing
- [x] follows guidelines
- [x] follows connector standards
- [ ] flight tested
- [x] comments/issues resolved

Built locally against current firmware with `make CONFIG=ARK_FPV`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the LSM6DSV16X accelerometer and gyroscope on SPI1 for the ARK FPV target.
  * Documented sensor compatibility across supported hardware revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->