### PR TITLE
Fix for RASPBERRY_PI_UAVFC - swap pins for BEC 5V, 9V enable

### DIFF
--- a/configs/RASP/RASPBERRY_PI_UAVFC/config.h
+++ b/configs/RASP/RASPBERRY_PI_UAVFC/config.h
@@ -130,10 +130,11 @@
 #define BEEPER_PIN           PA3
 
 #ifndef PICO_BEC_ENABLE_NONINVERTED
+// For this board, high means enable
 #define PICO_BEC_ENABLE_NONINVERTED 1
 #endif
-#define PICO_BEC_5V_ENABLE_PIN PA18
-#define PICO_BEC_9V_ENABLE_PIN PA19
+#define PICO_BEC_5V_ENABLE_PIN PA19
+#define PICO_BEC_9V_ENABLE_PIN PA18
 
 #define ADC_VBAT_PIN         PA46
 #define ADC_CURR_PIN         PA47


### PR DESCRIPTION
Fix for RASPBERRY_PI_UAVFC - swap pins for BEC 5V, 9V enable

The GPIOs for PICO_BEC_5V_ENABLE_PIN and PICO_BEC_9V_ENABLE_PIN were the wrong way round.
Swapping makes no functional difference, as each is separately enabled in the code according
to the GPIO number, but this clarifies in case a user wishes to override with PINIO or similar.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the hardware control pin assignments for the 5V and 9V BEC outputs.
  - Clarified that a high signal enables the BEC output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->